### PR TITLE
Make marker activity GT masks

### DIFF
--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -66,6 +66,7 @@ class SegmentationTFRecords:
         self.imaging_platform = imaging_platform
         self.tf_record_path = tf_record_path
         self.cell_type_key = cell_type_key
+        self.cell_table_path = cell_table_path
 
     def get_image(self, data_folder, marker):
         """Loads the images from a single data_folder
@@ -112,7 +113,8 @@ class SegmentationTFRecords:
             df:
                 The labels and corresponding cell types for the given sample
         """
-        return None
+
+        return self.cell_type_table[self.cell_type_table.SampleID == sample_name]
 
     def get_marker_activity(self, cell_types, marker):
         """Gets the marker activity for the given labels
@@ -211,6 +213,9 @@ class SegmentationTFRecords:
                 self.data_folders,
                 self.selected_markers,
             )
+
+        # load cell_types.csv
+        self.cell_type_table = pd.read_csv(self.cell_table_path)
 
     def make_tf_record(self, data_folders):
         """Iterates through the data_folders and loads, transforms and

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -119,7 +119,14 @@ class SegmentationTFRecords:
         """
         sample_subset = self.cell_type_table[self.cell_type_table.SampleID == sample_name]
         cell_types = sample_subset[self.cell_type_key].values
-        return conversion_matrix.loc[cell_types, marker].values
+
+        df = pd.DataFrame(
+            {
+                "labels": sample_subset[self.segment_label_key],
+                "activity": conversion_matrix.loc[cell_types, marker].values,
+            }
+        )
+        return df
 
     def get_marker_activity_mask(self, instance_mask, binary_mask, marker_activity):
         """Makes a mask from the marker activity
@@ -136,7 +143,7 @@ class SegmentationTFRecords:
                 The marker activity mask
         """
         out_mask = np.zeros_like(instance_mask)
-        for label, activity in enumerate(marker_activity, 1):
+        for label, activity in zip(marker_activity.labels, marker_activity.activity):
             out_mask[instance_mask == label] = activity
         out_mask[binary_mask == 0] = 0
         return out_mask

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -14,11 +14,20 @@ class SegmentationTFRecords:
     """Prepares the data for the segmentation model"""
 
     def __init__(
-        self, data_folders, cell_table_path, conversion_matrix_path,
-        imaging_platform, dataset, tile_size, tf_record_path,
-        selected_markers=None, normalization_dict_path=None,
-        normalization_quantile=0.99, cell_type_key="cluster_labels",
-        sample_key="SampleID", segmentation_fname="cell_segmentation",
+        self,
+        data_folders,
+        cell_table_path,
+        conversion_matrix_path,
+        imaging_platform,
+        dataset,
+        tile_size,
+        tf_record_path,
+        selected_markers=None,
+        normalization_dict_path=None,
+        normalization_quantile=0.99,
+        cell_type_key="cluster_labels",
+        sample_key="SampleID",
+        segmentation_fname="cell_segmentation",
         segment_label_key="labels",
     ):
         """Initializes SegmentationTFRecords and loads everything except the images
@@ -116,19 +125,28 @@ class SegmentationTFRecords:
 
         return self.cell_type_table[self.cell_type_table.SampleID == sample_name]
 
-    def get_marker_activity(self, cell_types, marker):
+    def get_marker_activity(self, cell_types, conversion_matrix, markers):
         """Gets the marker activity for the given labels
         Args:
-            cell_types list:
+            cell_types array:
                 The cell types to get the marker activity for
             marker (str, list):
                 The markers to get the activity for
+            conversion_matrix (pd.DataFrame):
+                The conversion matrix to use for the lookup
         Returns:
-            list:
+            np.array:
                 The marker activity for the given labels, 1 if the marker is active, 0
                 otherwise and -1 if the marker is not specific enough to be considered active
         """
-        return None
+        if isinstance(markers, str):
+            markers = [markers]
+
+        out_dict = {}
+        for marker in markers:
+            out_dict[marker] = conversion_matrix.loc[cell_types, marker].values
+
+        return out_dict
 
     def get_marker_activity_mask(self, instance_mask, cell_types, marker_activity):
         """Makes a mask from the marker activity


### PR DESCRIPTION
**What is the purpose of this PR?**

Constructing the gt marker activity masks given the cell segmentations, the conversion table and the cell table.

**How did you implement your changes**

I implemented the functions 
- `get_cell_types(sample_name)`: subsets `cell_table` and returns only the rows that come from the same FOV (i.e. same sample_name)
- `get_marker_activity(cell_types, conversion_matrix, markers)`: returns a dictionary with marker names as keys and lists of cells as values. The lists are binary and indicate if a given cell is marker positive or not
- `get_marker_activity_mask(instance_mask, binary_mask, marker_activity, markers)`: maps the marker activity onto the instance segmentation maps to return a spatial representation of positive/negative marker activity for a list of given markers.

**Remaining issues**

Some small things here and there could be done better. I am not happy with the marker activity dict. It looks like this
`{"marker":[1,0,0,0,1]}` where the first element of the list corresponds to marker activity in the cell segment with label 1. I think this list should be pre-pended with a zero so that the indexes of the list correspond to the cell labels. Anyways, I am interested in your comments and I guess you'll find more weaknesses.  
