### PR TITLE
Prepare example

### DIFF
--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -269,8 +269,22 @@ class SegmentationTFRecords:
             tf_record_path (str):
                 The path to the tf record to make
         """
+        # check input
+        #self.check_input()
+
+        for data_folder in data_folders:
+            for marker in self.selected_markers:
+                example = self.prepare_example(self, data_folder, marker)
+                if self.tile:
+                    example_list = self.tile_example(example)
+                else:
+                    example_list = [example]
+                for example in example_list:
+                    example_serialized = self.serialize_example(example)
+                    self.write_tf_record(example_serialized)
 
         return None
+
 
     def calculate_normalization_matrix(self, data_folders, selected_markers):
         """Calculates the normalization matrix for the given data if it does not exist

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -17,7 +17,7 @@ class SegmentationTFRecords:
     """Prepares the data for the segmentation model"""
 
     def __init__(
-        self, data_folders, cell_table_path, conversion_matrix_path,
+        self, data_dir, cell_table_path, conversion_matrix_path,
         imaging_platform, dataset, tile_size, stride, tf_record_path, selected_markers=None,
         normalization_dict_path=None, normalization_quantile=0.99,
         cell_type_key="cluster_labels", sample_key="SampleID",
@@ -327,7 +327,7 @@ class SegmentationTFRecords:
                 The path to the tf record to make
         """
         # check input
-        #self.check_input()
+        self.check_input()
 
         for data_folder in data_folders:
             for marker in self.selected_markers:
@@ -341,7 +341,6 @@ class SegmentationTFRecords:
                     self.write_tf_record(example_serialized)
 
         return None
-
 
     def calculate_normalization_matrix(self, data_folders, selected_markers):
         """Calculates the normalization matrix for the given data if it does not exist

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -351,6 +351,7 @@ class SegmentationTFRecords:
                 for example in example_list:
                     example_serialized = self.serialize_example(example)
                     self.writer.write(example_serialized)
+        self.writer.close()
         return None
 
     def serialize_example(self, example):

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -10,17 +10,17 @@ import copy
 
 
 def prep_object(
-    data_folders=["path"], cell_table_path="path", conversion_matrix_path="path",
+    data_dir="path", cell_table_path="path", conversion_matrix_path="path",
     normalization_dict_path="path", tf_record_path="path", tile_size=[256, 256],
-    stride=[256, 256],
+    stride=[256, 256], normalization_quantile=0.99, selected_markers=None
 ):
     data_prep = SegmentationTFRecords(
-        data_folders=data_folders, cell_table_path=cell_table_path,
+        data_dir=data_dir, cell_table_path=cell_table_path,
         conversion_matrix_path=conversion_matrix_path, imaging_platform="imaging_platform",
         dataset="dataset", tile_size=tile_size, stride=stride, tf_record_path=tf_record_path,
-        data_dir="path", cell_table_path="path", conversion_matrix_path="path",
-        normalization_dict_path="path", tf_record_path="path",
-        selected_markers=None, normalization_quantile=0.99,)
+        normalization_dict_path=normalization_dict_path, selected_markers=selected_markers,
+        normalization_quantile=normalization_quantile
+    )
     return data_prep
 
 

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -10,7 +10,6 @@ import copy
 
 
 def prep_object(
-<<<<<<< HEAD
     data_folders=["path"], cell_table_path="path", conversion_matrix_path="path",
     normalization_dict_path="path", tf_record_path="path", tile_size=[256, 256],
     stride=[256, 256],
@@ -19,21 +18,9 @@ def prep_object(
         data_folders=data_folders, cell_table_path=cell_table_path,
         conversion_matrix_path=conversion_matrix_path, imaging_platform="imaging_platform",
         dataset="dataset", tile_size=tile_size, stride=stride, tf_record_path=tf_record_path,
-=======
-    data_dir="path", cell_table_path="path", conversion_matrix_path="path",
-    normalization_dict_path="path", tf_record_path="path",
-    selected_markers=None, normalization_quantile=0.99,
-):
-    data_prep = SegmentationTFRecords(
-        data_dir=data_dir, cell_table_path=cell_table_path,
-        conversion_matrix_path=conversion_matrix_path,
-        imaging_platform="imaging_platform", dataset="dataset",
-        tile_size=[256, 256], tf_record_path=tf_record_path,
->>>>>>> main
-        normalization_dict_path=normalization_dict_path,
-        selected_markers=selected_markers,
-        normalization_quantile=normalization_quantile,
-    )
+        data_dir="path", cell_table_path="path", conversion_matrix_path="path",
+        normalization_dict_path="path", tf_record_path="path",
+        selected_markers=None, normalization_quantile=0.99,)
     return data_prep
 
 

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -428,6 +428,12 @@ def test_tile_example(tile_size):
         np.array([1, 2, 5], dtype=np.uint16)
     )
 
+    # check if channel gets added to images without channels
+    example["instance_mask"] = np.squeeze(example["instance_mask"], axis=-1)
+    tiled_examples = data_prep.tile_example(example)
+    assert tiled_examples[0]["instance_mask"].ndim == 3
+    assert tiled_examples[1]["instance_mask"].ndim == 3
+
 
 def test_prepare_example():
     data_prep = prep_object()

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -10,12 +10,13 @@ from segmentation_data_prep import SegmentationTFRecords
 
 def prep_object(
     data_folders=["path"], cell_table_path="path", conversion_matrix_path="path",
-    normalization_dict_path="path", tf_record_path="path",
+    normalization_dict_path="path", tf_record_path="path", tile_size=[256, 256],
+    stride=[256, 256],
 ):
     data_prep = SegmentationTFRecords(
         data_folders=data_folders, cell_table_path=cell_table_path,
         conversion_matrix_path=conversion_matrix_path, imaging_platform="imaging_platform",
-        dataset="dataset", tile_size=[256, 256], tf_record_path=tf_record_path,
+        dataset="dataset", tile_size=tile_size, stride=stride, tf_record_path=tf_record_path,
         normalization_dict_path=normalization_dict_path,
     )
     return data_prep
@@ -46,9 +47,7 @@ def test_get_image():
         assert not np.array_equal(CD8_img, CD4_img)
 
 
-def prepare_test_data_folders(
-    num_folders, temp_dir, selected_markers, random=False, scale=[1.0]
-):
+def prepare_test_data_folders(num_folders, temp_dir, selected_markers, random=False, scale=[1.0]):
     data_folders = []
     if len(scale) != num_folders:
         scale = [1.0] * num_folders
@@ -75,8 +74,7 @@ def prepare_cell_type_table():
         {
             "SampleID": ["fov_1"] * 6 + ["fov_2"] * 6,
             "labels": [1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6],
-            "cluster_labels": ["stromal", "FAP", "NK"] * 2
-            + ["CD4T", "CD14", "CD163"] * 2,
+            "cluster_labels": ["stromal", "FAP", "NK"] * 2 + ["CD4T", "CD14", "CD163"] * 2,
         }
     )
 
@@ -109,9 +107,7 @@ def test_calculate_normalization_matrix():
             assert norm_dict[marker] - 1 / (0.5 * std) < 0.001
 
         # check if the normalization_dict is correctly written to the json file
-        norm_dict_loaded = json.load(
-            open(os.path.join(temp_dir, "norm_dict_test.json"))
-        )
+        norm_dict_loaded = json.load(open(os.path.join(temp_dir, "norm_dict_test.json")))
         assert norm_dict_loaded == norm_dict
 
         # check if the normalization_dict has the correct keys
@@ -175,9 +171,7 @@ def test_get_inst_binary_masks():
         # check if the instance_mask is correctly loaded
         imwrite(os.path.join(temp_dir, "cell_segmentation.tiff"), instance_mask)
         data_prep = prep_object()
-        loaded_binary_img, loaded_img = data_prep.get_inst_binary_masks(
-            data_folder=temp_dir
-        )
+        loaded_binary_img, loaded_img = data_prep.get_inst_binary_masks(data_folder=temp_dir)
         assert np.array_equal(loaded_img, instance_mask)
 
         # check if binary mask is binarized correctly
@@ -195,9 +189,7 @@ def test_get_marker_activity():
     marker = "CD11c"
     sample_name = "fov_1"
     fov_1_subset = cell_table[cell_table.SampleID == sample_name]
-    marker_activity = data_prep.get_marker_activity(
-        sample_name, conversion_matrix, marker
-    )
+    marker_activity = data_prep.get_marker_activity(sample_name, conversion_matrix, marker)
 
     # check if the we get marker_acitivity for all labels in the fov_1 subset
     assert np.array_equal(marker_activity.labels, fov_1_subset.labels)
@@ -248,18 +240,14 @@ def test_tile_example():
         "mplex_img": np.random.rand(512, 512, 3).astype(np.float32),
         "binary_mask": np.random.randint(0, 2, [512, 512, 1]).astype(np.uint8),
         "instance_mask": np.random.randint(0, 10000, [512, 512]).astype(np.uint16),
-        "marker_activity_mask": np.random.randint(0, 2, [512, 512, 21]).astype(
-            np.uint8
-        ),
+        "marker_activity_mask": np.random.randint(0, 2, [512, 512, 21]).astype(np.uint8),
         "dataset": "test_dataset",
         "platform": "mibi",
         "cell_types": ["CD11c", "CD11b", "CD11a"],
         "marker": "CD11c",
     }
-    data_prep = prep_object()
-    tiled_examples = data_prep.tile_example(
-        example, tile_size=[128, 128], stride=[128, 128]
-    )
+    data_prep = prep_object(tile_size=[128, 128], stride=[128, 128])
+    tiled_examples = data_prep.tile_example(example)
 
     # check if the right number of tiles got returned
     assert len(tiled_examples) == 16

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -170,7 +170,7 @@ def test_load_and_check_input():
         data_prep = prep_object(
             data_dir=temp_dir,
             conversion_matrix_path=conversion_matrix_path,
-            tf_record_path="path",
+            tf_record_path=temp_dir,
             cell_table_path=cell_table_path,
             normalization_dict_path=os.path.join(temp_dir, "norm_dict.json"),
             selected_markers=["CD4"],
@@ -190,7 +190,7 @@ def test_load_and_check_input():
         data_prep = prep_object(
             data_dir=temp_dir,
             conversion_matrix_path=conversion_matrix_path,
-            tf_record_path="path",
+            tf_record_path=temp_dir,
             normalization_dict_path=os.path.join(temp_dir, "norm_dict.json"),
             cell_table_path=cell_table_path,
         )
@@ -514,11 +514,12 @@ def test_make_tf_record():
         data_prep, data_folders, _, _ = prep_object_and_inputs(temp_dir)
         data_prep.tf_record_path = temp_dir
         data_prep.make_tf_record()
+        tf_record_path = os.path.join(temp_dir, data_prep.dataset + ".tfrecord")
         # check if tf record was created
-        assert os.path.exists(os.path.join(temp_dir, data_prep.dataset + ".tfrecord"))
+        assert os.path.exists(tf_record_path)
 
         # check if tf record has the right number of examples
-        dataset = tf.data.TFRecordDataset(os.path.join(temp_dir, data_prep.dataset + ".tfrecord"))
+        dataset = tf.data.TFRecordDataset(tf_record_path)
         num_examples = 0
         for string_record in dataset:
             num_examples += 1


### PR DESCRIPTION
**What is the purpose of this PR?**

Adding the remaining functionalities `make_tf_record`, `serialize_example`, `tile_example` and `prepare_example` as well as the parse function `parse_dict` that takes a tfrecord example consisting of byte strings and parses it into a dict of tensors, dataframes and strings. This PR closes #1.

**How did you implement your changes**

Added the above mentioned functionality to `segmentation_data_prep.py` and wrote the tests for it.

**Remaining issues**

None hopefully. I could add a `main` method and an `argparse` CLI if this is desired?
