### PR TITLE
Plot utils

### DIFF
--- a/cell_classification/plot_utils.py
+++ b/cell_classification/plot_utils.py
@@ -9,13 +9,14 @@ import numpy as np
 import argparse
 from tqdm import tqdm
 
+
 def segmentation_to_boundaries(labels):
-    """ Convert a segmentation to a binary mask of the boundaries
-    
+    """Convert a segmentation to a binary mask of the boundaries
+
     Args:
         segmentation (np.ndarray):
             A 2D array of integers representing a segmentation
-    
+
     Returns:
         np.ndarray:
             A 2D array of booleans representing the boundaries of the segmentation
@@ -25,9 +26,9 @@ def segmentation_to_boundaries(labels):
     return boundaries
 
 
-def plot_overlay(example, dpi=None, save_dir=None, save_file=None):
-    """ Plot the marker image and the marker activity segmentation overlayed
-    
+def plot_overlay(example, save_dir=None, save_file=None, dpi=160):
+    """Plot the marker image and the marker activity segmentation overlayed
+
     Args:
         example (dict):
             Dictionary with keys "mplex_img", "marker_activity_mask"
@@ -41,27 +42,30 @@ def plot_overlay(example, dpi=None, save_dir=None, save_file=None):
     """
     marker_boundaries = segmentation_to_boundaries(example["marker_activity_mask"].numpy())
     instance_mask = example["instance_mask"].numpy()
-    instance_mask[example["marker_activity_mask"].numpy()>0] = 0
-    other_boundaries = segmentation_to_boundaries(instance_mask)>0
-    img = np.repeat(example["mplex_img"], 3 , axis=-1)#/example["mplex_img"].numpy().max()
+    instance_mask[example["marker_activity_mask"].numpy() > 0] = 0
+    other_boundaries = segmentation_to_boundaries(instance_mask) > 0
+    img = np.repeat(example["mplex_img"], 3, axis=-1)
     img[np.squeeze(other_boundaries)] = 0.2
-    colors = [(0,0,0), (0,1,0), (0,0,1), (1,0,0)]
+    colors = [(0, 0, 0), (0, 1, 0), (0, 0, 1), (1, 0, 0)]
     for i, val in enumerate(np.unique(marker_boundaries)):
         if val == 0:
             continue
-        img[np.squeeze(marker_boundaries)==val] = colors[i]
-    pos = mpatches.Patch(color=(0, 1, 0), label='Positive')
-    neg = mpatches.Patch(color=(0, 0, 0), label='Negative')
-    und = mpatches.Patch(color=(0, 0, 1), label='Undetermined')
-    oth = mpatches.Patch(color=(0.4, 0.4, 0.4), label='Others')
-    fig = plt.figure()
+        img[np.squeeze(marker_boundaries) == val] = colors[i]
+    pos = mpatches.Patch(color=(0, 1, 0), label="Positive")
+    neg = mpatches.Patch(color=(0, 0, 0), label="Negative")
+    und = mpatches.Patch(color=(0, 0, 1), label="Undetermined")
+    oth = mpatches.Patch(color=(0.4, 0.4, 0.4), label="Others")
     ax = plt.subplot(111)
-    ax.imshow(img.clip(0,1), interpolation='nearest')
+    ax.imshow(img.clip(0, 1), interpolation="nearest")
     box = ax.get_position()
-    ax.set_position([box.x0, box.y0 + box.height * 0.1,
-                    box.width, box.height * 0.9])
-    plt.legend(handles=[pos, neg, und, oth], loc='upper center', bbox_to_anchor=(0.5, -0.05),
-            fancybox=True, ncol=3)
+    ax.set_position([box.x0, box.y0 + box.height * 0.1, box.width, box.height * 0.9])
+    plt.legend(
+        handles=[pos, neg, und, oth],
+        loc="upper center",
+        bbox_to_anchor=(0.5, -0.05),
+        fancybox=True,
+        ncol=3,
+    )
     plt.tight_layout()
     if save_dir:
         os.makedirs(save_dir, exist_ok=True)
@@ -70,27 +74,32 @@ def plot_overlay(example, dpi=None, save_dir=None, save_file=None):
         plt.show()
     plt.close()
 
-def plot_together(example, dpi=None, save_dir=None, save_file=None):
+
+def plot_together(example, save_dir=None, save_file=None, dpi=160):
     colors = [(0, 0, 0), (0, 1, 0), (0, 0, 1), (1, 0, 0)]
     cmap = LinearSegmentedColormap.from_list("BRGB", colors, N=4)
     fig, ax = plt.subplots(1, 3)
-    ax[0].imshow(example["mplex_img"].numpy().clip(0,1), interpolation='nearest', cmap='gray')
-    ax[1].imshow(example["binary_mask"].numpy(), interpolation='nearest', cmap="gray")
+    ax[0].imshow(example["mplex_img"].numpy().clip(0, 1), interpolation="nearest", cmap="gray")
+    ax[1].imshow(example["binary_mask"].numpy(), interpolation="nearest", cmap="gray")
     ax[2].imshow(
-        example["marker_activity_mask"].numpy(), interpolation='nearest', cmap=cmap, vmin=0, vmax=3
-        )
-    ax[0].title.set_text('mplex img')
-    ax[1].title.set_text('binary_mask')
-    ax[2].title.set_text('marker_activity_mask')
-    pos = mpatches.Patch(color=colors[1], label='Positive')
-    neg = mpatches.Patch(color=colors[0], label='Negative')
-    und = mpatches.Patch(color=colors[3], label='Undetermined')
+        example["marker_activity_mask"].numpy(), interpolation="nearest", cmap=cmap, vmin=0, vmax=3
+    )
+    ax[0].title.set_text("mplex img")
+    ax[1].title.set_text("binary_mask")
+    ax[2].title.set_text("marker_activity_mask")
+    pos = mpatches.Patch(color=colors[1], label="Positive")
+    neg = mpatches.Patch(color=colors[0], label="Negative")
+    und = mpatches.Patch(color=colors[3], label="Undetermined")
     for axx in ax:
         box = axx.get_position()
-        axx.set_position([box.x0, box.y0 + box.height * 0.1,
-                        box.width, box.height * 0.9])
-    ax[1].legend(handles=[pos, neg, und], loc='upper center', bbox_to_anchor=(-0.1, -0.2),
-            fancybox=True, ncol=3)
+        axx.set_position([box.x0, box.y0 + box.height * 0.1, box.width, box.height * 0.9])
+    ax[1].legend(
+        handles=[pos, neg, und],
+        loc="upper center",
+        bbox_to_anchor=(-0.1, -0.2),
+        fancybox=True,
+        ncol=3,
+    )
     if save_dir:
         os.makedirs(save_dir, exist_ok=True)
         plt.savefig(os.path.join(save_dir, save_file), dpi=dpi)
@@ -98,14 +107,17 @@ def plot_together(example, dpi=None, save_dir=None, save_file=None):
         plt.show()
     plt.close()
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--record_path", type=str,
-        default="C:/Users/lorenz/Downloads/Lorenz_example_data/TNBC.tfrecord"
+        "--record_path",
+        type=str,
+        default="C:/Users/lorenz/Downloads/Lorenz_example_data/TNBC.tfrecord",
     )
-    parser.add_argument("--save_dir", type=str,
-        default="C:/Users/lorenz/Downloads/Lorenz_example_data/plots")
+    parser.add_argument(
+        "--save_dir", type=str, default="C:/Users/lorenz/Downloads/Lorenz_example_data/plots"
+    )
     parser.add_argument("--dpi", type=float, default=160)
     parser.add_argument("--plot_overlay", default=True)
     args = parser.parse_args()
@@ -116,5 +128,15 @@ if __name__ == "__main__":
     for i, record in tqdm(enumerate(train_ds)):
         example_encoded = tf.io.parse_single_example(record, feature_description)
         example = parse_dict(example_encoded)
-        plot_overlay(example, dpi=dpi, save_dir=save_dir, save_file=f"overlay_{i}.png")
-        plot_together(example, dpi=dpi, save_dir=save_dir, save_file=f"together_{i}.png")
+        plot_overlay(
+            example,
+            dpi=dpi,
+            save_dir=save_dir,
+            save_file=f"{example['folder_name']}_overlay_{i}.png",
+        )
+        plot_together(
+            example,
+            dpi=dpi,
+            save_dir=save_dir,
+            save_file=f"{example['folder_name']}_together_{i}.png",
+        )

--- a/cell_classification/plot_utils.py
+++ b/cell_classification/plot_utils.py
@@ -1,0 +1,120 @@
+import os
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+from matplotlib.colors import LinearSegmentedColormap
+from segmentation_data_prep import parse_dict, feature_description
+import tensorflow as tf
+from skimage.segmentation import find_boundaries
+import numpy as np
+import argparse
+from tqdm import tqdm
+
+def segmentation_to_boundaries(labels):
+    """ Convert a segmentation to a binary mask of the boundaries
+    
+    Args:
+        segmentation (np.ndarray):
+            A 2D array of integers representing a segmentation
+    
+    Returns:
+        np.ndarray:
+            A 2D array of booleans representing the boundaries of the segmentation
+    """
+    boundaries = find_boundaries(labels, mode="inner")
+    boundaries = labels * boundaries.astype(labels.dtype)
+    return boundaries
+
+
+def plot_overlay(example, dpi=None, save_dir=None, save_file=None):
+    """ Plot the marker image and the marker activity segmentation overlayed
+    
+    Args:
+        example (dict):
+            Dictionary with keys "mplex_img", "marker_activity_mask"
+        dpi (float):
+            The resolution of the image to save, ignored if save_dir is None
+        save_dir (str):
+            If specified, a directory where we will save the plot
+        save_file (str):
+            If save_dir specified, specify a file name you wish to save to.
+            Ignored if save_dir is None
+    """
+    marker_boundaries = segmentation_to_boundaries(example["marker_activity_mask"].numpy())
+    instance_mask = example["instance_mask"].numpy()
+    instance_mask[example["marker_activity_mask"].numpy()>0] = 0
+    other_boundaries = segmentation_to_boundaries(instance_mask)>0
+    img = np.repeat(example["mplex_img"], 3 , axis=-1)#/example["mplex_img"].numpy().max()
+    img[np.squeeze(other_boundaries)] = 0.2
+    colors = [(0,0,0), (0,1,0), (0,0,1), (1,0,0)]
+    for i, val in enumerate(np.unique(marker_boundaries)):
+        if val == 0:
+            continue
+        img[np.squeeze(marker_boundaries)==val] = colors[i]
+    pos = mpatches.Patch(color=(0, 1, 0), label='Positive')
+    neg = mpatches.Patch(color=(0, 0, 0), label='Negative')
+    und = mpatches.Patch(color=(0, 0, 1), label='Undetermined')
+    oth = mpatches.Patch(color=(0.4, 0.4, 0.4), label='Others')
+    fig = plt.figure()
+    ax = plt.subplot(111)
+    ax.imshow(img.clip(0,1), interpolation='nearest')
+    box = ax.get_position()
+    ax.set_position([box.x0, box.y0 + box.height * 0.1,
+                    box.width, box.height * 0.9])
+    plt.legend(handles=[pos, neg, und, oth], loc='upper center', bbox_to_anchor=(0.5, -0.05),
+            fancybox=True, ncol=3)
+    plt.tight_layout()
+    if save_dir:
+        os.makedirs(save_dir, exist_ok=True)
+        plt.savefig(os.path.join(save_dir, save_file), dpi=dpi)
+    else:
+        plt.show()
+    plt.close()
+
+def plot_together(example, dpi=None, save_dir=None, save_file=None):
+    colors = [(0, 0, 0), (0, 1, 0), (0, 0, 1), (1, 0, 0)]
+    cmap = LinearSegmentedColormap.from_list("BRGB", colors, N=4)
+    fig, ax = plt.subplots(1, 3)
+    ax[0].imshow(example["mplex_img"].numpy().clip(0,1), interpolation='nearest', cmap='gray')
+    ax[1].imshow(example["binary_mask"].numpy(), interpolation='nearest', cmap="gray")
+    ax[2].imshow(
+        example["marker_activity_mask"].numpy(), interpolation='nearest', cmap=cmap, vmin=0, vmax=3
+        )
+    ax[0].title.set_text('mplex img')
+    ax[1].title.set_text('binary_mask')
+    ax[2].title.set_text('marker_activity_mask')
+    pos = mpatches.Patch(color=colors[1], label='Positive')
+    neg = mpatches.Patch(color=colors[0], label='Negative')
+    und = mpatches.Patch(color=colors[3], label='Undetermined')
+    for axx in ax:
+        box = axx.get_position()
+        axx.set_position([box.x0, box.y0 + box.height * 0.1,
+                        box.width, box.height * 0.9])
+    ax[1].legend(handles=[pos, neg, und], loc='upper center', bbox_to_anchor=(-0.1, -0.2),
+            fancybox=True, ncol=3)
+    if save_dir:
+        os.makedirs(save_dir, exist_ok=True)
+        plt.savefig(os.path.join(save_dir, save_file), dpi=dpi)
+    else:
+        plt.show()
+    plt.close()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--record_path", type=str,
+        default="C:/Users/lorenz/Downloads/Lorenz_example_data/TNBC.tfrecord"
+    )
+    parser.add_argument("--save_dir", type=str,
+        default="C:/Users/lorenz/Downloads/Lorenz_example_data/plots")
+    parser.add_argument("--dpi", type=float, default=160)
+    parser.add_argument("--plot_overlay", default=True)
+    args = parser.parse_args()
+    path = args.record_path
+    save_dir = args.save_dir
+    dpi = args.dpi
+    train_ds = tf.data.TFRecordDataset(path)
+    for i, record in tqdm(enumerate(train_ds)):
+        example_encoded = tf.io.parse_single_example(record, feature_description)
+        example = parse_dict(example_encoded)
+        plot_overlay(example, dpi=dpi, save_dir=save_dir, save_file=f"overlay_{i}.png")
+        plot_together(example, dpi=dpi, save_dir=save_dir, save_file=f"together_{i}.png")

--- a/cell_classification/plot_utils.py
+++ b/cell_classification/plot_utils.py
@@ -1,3 +1,4 @@
+from ast import arg
 import os
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
@@ -120,11 +121,14 @@ if __name__ == "__main__":
     )
     parser.add_argument("--dpi", type=float, default=160)
     parser.add_argument("--plot_overlay", default=True)
+    parser.add_argument("--shuffle", default=True)
     args = parser.parse_args()
     path = args.record_path
     save_dir = args.save_dir
     dpi = args.dpi
     train_ds = tf.data.TFRecordDataset(path)
+    if args.shuffle:
+        train_ds = train_ds.shuffle(300)
     for i, record in tqdm(enumerate(train_ds)):
         example_encoded = tf.io.parse_single_example(record, feature_description)
         example = parse_dict(example_encoded)
@@ -132,11 +136,11 @@ if __name__ == "__main__":
             example,
             dpi=dpi,
             save_dir=save_dir,
-            save_file=f"{example['folder_name']}_overlay_{i}.png",
+            save_file=f"{example['folder_name']}_{example['marker']}_overlay_{i}.png",
         )
         plot_together(
             example,
             dpi=dpi,
             save_dir=save_dir,
-            save_file=f"{example['folder_name']}_together_{i}.png",
+            save_file=f"{example['folder_name']}_{example['marker']}_together_{i}.png",
         )

--- a/cell_classification/plot_utils_test.py
+++ b/cell_classification/plot_utils_test.py
@@ -1,0 +1,48 @@
+from segmentation_data_prep import parse_dict, feature_description
+from segmentation_data_prep_test import prep_object_and_inputs
+import pytest
+import tempfile
+from plot_utils import plot_overlay, plot_together
+import os
+import tensorflow as tf
+
+
+def prepare_dataset(temp_dir):
+    data_prep, _, _, _ = prep_object_and_inputs(temp_dir)
+    data_prep.tf_record_path = temp_dir
+    data_prep.make_tf_record()
+    tf_record_path = os.path.join(temp_dir, data_prep.dataset + ".tfrecord")
+    dataset = tf.data.TFRecordDataset(tf_record_path)
+    return dataset
+
+
+def test_plot_overlay():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        dataset = iter(prepare_dataset(temp_dir))
+        plot_path = os.path.join(temp_dir, "plots")
+        os.makedirs(plot_path, exist_ok=True)
+        record = next(dataset)
+        example_encoded = tf.io.parse_single_example(record, feature_description)
+        example = parse_dict(example_encoded)
+        plot_overlay(
+            example, save_dir=plot_path, save_file=f"{example['folder_name']}_overlay.png"
+        )
+
+        # check if plot was saved
+        assert os.path.exists(os.path.join(plot_path, f"{example['folder_name']}_overlay.png"))
+
+
+def test_plot_together():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        dataset = iter(prepare_dataset(temp_dir))
+        plot_path = os.path.join(temp_dir, "plots")
+        os.makedirs(plot_path, exist_ok=True)
+        record = next(dataset)
+        example_encoded = tf.io.parse_single_example(record, feature_description)
+        example = parse_dict(example_encoded)
+        plot_together(
+            example, save_dir=plot_path, save_file=f"{example['folder_name']}_together.png"
+        )
+
+        # check if plot was saved
+        assert os.path.exists(os.path.join(plot_path, f"{example['folder_name']}_together.png"))

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -128,7 +128,7 @@ class SegmentationTFRecords:
                 The marker activity for the given labels, 1 if the marker is active, 0
                 otherwise and -1 if the marker is not specific enough to be considered active
         """
-        sample_subset = self.cell_type_table[self.cell_type_table.SampleID == sample_name]
+        sample_subset = self.cell_type_table[self.cell_type_table[self.sample_key] == sample_name]
         cell_types = sample_subset[self.cell_type_key].values
 
         df = pd.DataFrame(
@@ -340,6 +340,11 @@ class SegmentationTFRecords:
             data_folders=list_folders(self.data_dir),
             warn=True
         )
+
+        # make cell_types lowercase to make matching easier
+        self.conversion_matrix.index = self.conversion_matrix.index.str.lower()
+        self.cell_type_table[self.cell_type_key] = self.cell_type_table[self.cell_type_key] \
+            .str.lower()
 
     def make_tf_record(self):
         """Iterates through the data_folders and loads, transforms and

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -335,10 +335,11 @@ class SegmentationTFRecords:
             raise ValueError("The sample_key is not in the cell_type_table")
 
         # check if sample_names in cell_type_table match sample_names in data_folder
-        # verify_in_list(
-        #     sample_names=self.cell_type_table[self.sample_key].values,
-        #     data_folders=list_folders(self.data_dir),
-        # )
+        verify_in_list(
+            sample_names=self.cell_type_table[self.sample_key].values,
+            data_folders=list_folders(self.data_dir),
+            warn=True
+        )
 
     def make_tf_record(self):
         """Iterates through the data_folders and loads, transforms and
@@ -391,8 +392,7 @@ class SegmentationTFRecords:
             if type(example[key]) in [np.ndarray, tf.Tensor]:
                 # convert float32 into uint16 for compression and storage
                 if example[key].dtype not in [np.uint8, np.uint16]:
-                    
-                    example[key] = example[key].clip(0,20) * (np.iinfo(np.uint16).max/20)
+                    example[key] = example[key].clip(0, 20) * (np.iinfo(np.uint16).max/20)
                     example[key] = example[key].astype(np.uint16)
                 # convert to bytes
                 string_example[key] = tf.io.encode_png(example[key]).numpy()

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -95,8 +95,10 @@ def prepare_test_data_folders(num_folders, temp_dir, selected_markers, random=Fa
                 img,
             )
         imwrite(
-            os.path.join(folder, "cell_segmentation.tiff"),
-            np.random.randint(0, 255, size=(256, 256)),
+            os.path.join(
+                folder, "cell_segmentation.tiff"), np.array(
+                    [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]
+                ).repeat(64, axis=1).repeat(64, axis=0)
         )
     return data_folders
 

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -13,7 +13,7 @@ import tensorflow as tf
 def prep_object(
     data_dir="path", cell_table_path="path", conversion_matrix_path="path",
     normalization_dict_path="path", tf_record_path="path", tile_size=[256, 256], stride=[256, 256],
-    normalization_quantile=0.99, selected_markers=None,
+    normalization_quantile=0.999, selected_markers=None,
 ):
     data_prep = SegmentationTFRecords(
         data_dir=data_dir, cell_table_path=cell_table_path,
@@ -140,7 +140,7 @@ def test_calculate_normalization_matrix():
 
         # check if the normalization_dict has the correct values for stochastic images
         for marker, std in zip(norm_dict.keys(), scale):
-            assert np.isclose(norm_dict[marker], std * 0.99, rtol=1e-3)
+            assert np.isclose(norm_dict[marker], std * 0.999, rtol=1e-3)
 
         # check if the normalization_dict is correctly written to the json file
         norm_dict_loaded = json.load(open(os.path.join(temp_dir, "norm_dict_test.json")))
@@ -453,7 +453,7 @@ def test_prepare_example():
         )
 
         # check correct normalization of mplex_img
-        assert np.isclose(np.quantile(example["mplex_img"], 0.99), 1.0, rtol=1e-2)
+        assert np.isclose(np.quantile(example["mplex_img"], 0.999), 1.0, rtol=1e-2)
         assert example["mplex_img"].min() >= 0.0
 
         # check if all images are 3 dimensional

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -138,7 +138,7 @@ def test_calculate_normalization_matrix():
 
         # check if the normalization_dict has the correct values for stochastic images
         for marker, std in zip(norm_dict.keys(), scale):
-            assert np.isclose(norm_dict[marker], 1 / (std * 0.99), rtol=1e-3)
+            assert np.isclose(norm_dict[marker], std * 0.99, rtol=1e-3)
 
         # check if the normalization_dict is correctly written to the json file
         norm_dict_loaded = json.load(open(os.path.join(temp_dir, "norm_dict_test.json")))
@@ -277,7 +277,7 @@ def test_load_and_check_input():
         cell_table_path_tmp = os.path.join(temp_dir, "cell_type_table_wrong_sample.csv")
         cell_table.to_csv(cell_table_path_tmp, index=False)
         data_prep.cell_table_path = cell_table_path_tmp
-        with pytest.raises(ValueError, match="list sample names were found in list data folder."):
+        with pytest.warns(UserWarning):
             data_prep.load_and_check_input()
 
 
@@ -449,7 +449,7 @@ def test_prepare_example():
         )
 
         # check correct normalization of mplex_img
-        assert example["mplex_img"].max() <= 1.0
+        assert np.isclose(np.quantile(example["mplex_img"], 0.99), 1.0, rtol=1e-2)
         assert example["mplex_img"].min() >= 0.0
 
         # check if all images are 3 dimensional
@@ -479,7 +479,7 @@ def test_serialize_example():
         for key in ["binary_mask", "marker_activity_mask", "instance_mask"]:
             assert np.array_equal(example[key], parsed_example[key].numpy())
         # check if mplex_img (float32) is correctly reconstructed from uint16 png
-        assert np.allclose(example["mplex_img"], parsed_example["mplex_img"].numpy(), atol=1e-4)
+        assert np.allclose(example["mplex_img"], parsed_example["mplex_img"].numpy(), atol=1e-3)
 
 
 def test_make_tf_record():
@@ -517,7 +517,7 @@ def test_make_tf_record():
         for key in ["binary_mask", "marker_activity_mask", "instance_mask"]:
             assert np.array_equal(example[key], parsed_dict[key].numpy())
         # check if mplex_img (float32) is correctly reconstructed from uint16 png
-        assert np.allclose(example["mplex_img"], parsed_dict["mplex_img"].numpy(), atol=1e-4)
+        assert np.allclose(example["mplex_img"], parsed_dict["mplex_img"].numpy(), atol=1e-3)
 
         # remove tiled-tfrecord and check if everything works with tile_size = None
         os.remove(tf_record_path)

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -246,9 +246,11 @@ def test_load_and_check_input():
         # CELL TYPE TABLE
         # check if cell_type_table is loaded correctly in check_input
         # when cell_type_table_path is given to init
+        conversion_matrix.to_csv(conversion_matrix_path, index=True)
         data_prep = copy.deepcopy(data_prep_working)
         data_prep.cell_type_table_path = cell_table_path
         data_prep.load_and_check_input()
+        cell_table["cluster_labels"] = cell_table["cluster_labels"].str.lower()
         assert np.array_equal(cell_table, data_prep.cell_type_table)
 
         # check if ValueError is raised when cell_type_key not in cell_type_table


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

This PR adds some plotting utils to inspect the examples in the tfrecord to close #15. Also it adds small changes to `segmentation_data_prep.py` based on errors that occured when wrangling real data with it.

**How did you implement your changes**

There are two plotting functions:
- `plot_overlay` which plots the boundaries of all cells overlayed onto the marker image with positive cells highlighted in green, unspecific cells highlighted in blue and the rest highlighted in gray.
- `plot_together` which plots the marker image, the binary cell masks and the ground truth marker activity mask (again positive/unspecific are highlighted in green/blue).

Another key change is that `SegmentationTFRecords` now uses the 0.999 quantile by default for normalization of the marker image and clips all values above it. In addition, the class also sets `cell_table[cell_type_key]` and `conversion_matrix.index` to lower case. This could have negative consequences if there exists a cell type name that should be case sensitive. 

**Remaining issues**

Test coverage of `plot_utils.py` is fairly low, because I didn't write tests for the CLI. 
