### PR TITLE
Implemented subset plots

### DIFF
--- a/cell_classification/configs/params.toml
+++ b/cell_classification/configs/params.toml
@@ -30,7 +30,7 @@ steps_per_epoch = 100
 loss_fn = "BinaryCrossentropy"
 loss_selective_masking = true
 [loss_kwargs]
-from_logits = true
+from_logits = false
 label_smoothing = 0.1
 
 [classes]

--- a/cell_classification/evaluation_script.py
+++ b/cell_classification/evaluation_script.py
@@ -3,8 +3,10 @@ import toml
 import os
 import pickle
 import pandas as pd
+import numpy as np
 from metrics import load_model_and_val_data, calc_roc, average_roc, calc_metrics
-from plot_utils import plot_average_roc, plot_metrics_against_threshold
+from plot_utils import plot_average_roc, plot_metrics_against_threshold, subset_plots
+from plot_utils import collapse_activity_dfs
 
 
 if __name__ == "__main__":
@@ -29,6 +31,7 @@ if __name__ == "__main__":
     params["model_path"] = args.model_path
     model, val_dset = load_model_and_val_data(params)
     params["eval_dir"] = os.path.join(params["model_dir"], "eval")
+    os.makedirs(params["eval_dir"], exist_ok=True)
     pred_list = model.predict_dataset(val_dset, True)
 
     # pixel level evaluation
@@ -74,4 +77,22 @@ if __name__ == "__main__":
         threshold_key="threshold",
         save_dir=params["eval_dir"],
         save_file="precision_recall_f1_cell_lvl.png",
+    )
+
+    print("Plot activity predictions split by markers and cell types")
+    activity_df = collapse_activity_dfs(pred_list)
+    subset_plots(
+        activity_df, subset_list=["marker"],
+        save_dir=params["eval_dir"],
+        save_file="split_by_marker.png"
+    )
+    subset_plots(
+        activity_df, subset_list=["cell_type"],
+        save_dir=params["eval_dir"],
+        save_file="split_by_marker.png"
+    )
+    subset_plots(
+        activity_df, subset_list=["marker", "cell_type"],
+        save_dir=params["eval_dir"],
+        save_file="split_by_marker_ct.png"
     )

--- a/cell_classification/evaluation_script.py
+++ b/cell_classification/evaluation_script.py
@@ -6,7 +6,9 @@ import pandas as pd
 import numpy as np
 from metrics import load_model_and_val_data, calc_roc, average_roc, calc_metrics
 from plot_utils import plot_average_roc, plot_metrics_against_threshold, subset_plots
-from plot_utils import collapse_activity_dfs
+from plot_utils import collapse_activity_dfs, subset_activity_df
+import matplotlib.pyplot as plt
+from metrics import calc_scores
 
 
 if __name__ == "__main__":
@@ -16,23 +18,23 @@ if __name__ == "__main__":
         type=str,
         help="Path to model weights",
         default="C:\\Users\\lorenz\\Desktop\\angelo_lab\\cell_classification\\checkpoints\\" +
-        "ex_1.h5",
+        "ex_2\\ex_2.h5",
     )
     parser.add_argument(
         "--params_path",
         type=str,
         help="Path to model params",
-        default="C:\\Users\\lorenz\\Desktop\\angelo_lab\\cell_classification\\"
-        + "cell_classification\\configs\\params.toml",
+        default="C:\\Users\\lorenz\\Desktop\\angelo_lab\\cell_classification\\checkpoints\\"
+        + "ex_2\\params.toml",
     )
     args = parser.parse_args()
     with open(args.params_path, "r") as f:
         params = toml.load(f)
     params["model_path"] = args.model_path
     model, val_dset = load_model_and_val_data(params)
-    params["eval_dir"] = os.path.join(params["model_dir"], "eval")
+    params["eval_dir"] = os.path.join(*os.path.split(params["model_path"])[:-1], "eval")
     os.makedirs(params["eval_dir"], exist_ok=True)
-    pred_list = model.predict_dataset(val_dset, True)
+    pred_list = model.predict_dataset(val_dset, False)
 
     # pixel level evaluation
     print("Calculate ROC curve")
@@ -43,18 +45,18 @@ if __name__ == "__main__":
     plot_average_roc(mean_tprs, std, save_dir=params["eval_dir"], save_file="avg_roc.png")
     print("AUC: {}".format(np.mean(roc["auc"])))
 
-    print("Calculate precision, recall, f1_score and accuracy")
-    avg_metrics = calc_metrics(pred_list)
-    pd.DataFrame(avg_metrics).to_csv(
-        os.path.join(params["eval_dir"], "pixel_metrics.csv"), index=False
-    )
-    plot_metrics_against_threshold(
-        avg_metrics,
-        metric_keys=["precision", "recall", "f1_score"],
-        threshold_key="threshold",
-        save_dir=params["eval_dir"],
-        save_file="precision_recall_f1.png",
-    )
+    # print("Calculate precision, recall, f1_score and accuracy")
+    # avg_metrics = calc_metrics(pred_list)
+    # pd.DataFrame(avg_metrics).to_csv(
+    #     os.path.join(params["eval_dir"], "pixel_metrics.csv"), index=False
+    # )
+    # plot_metrics_against_threshold(
+    #     avg_metrics,
+    #     metric_keys=["precision", "recall", "f1_score"],
+    #     threshold_key="threshold",
+    #     save_dir=params["eval_dir"],
+    #     save_file="precision_recall_f1.png",
+    # )
 
     # cell level evaluation
     roc = calc_roc(pred_list, gt_key="activity", pred_key="pred_activity", cell_level=True)
@@ -73,7 +75,7 @@ if __name__ == "__main__":
     )
     plot_metrics_against_threshold(
         avg_metrics,
-        metric_keys=["precision", "recall", "f1_score"],
+        metric_keys=["precision", "recall", "f1_score", "specificity"],
         threshold_key="threshold",
         save_dir=params["eval_dir"],
         save_file="precision_recall_f1_cell_lvl.png",
@@ -81,18 +83,27 @@ if __name__ == "__main__":
 
     print("Plot activity predictions split by markers and cell types")
     activity_df = collapse_activity_dfs(pred_list)
+    activity_df.to_csv(
+        os.path.join(params["eval_dir"], "pred_activity_df.csv"), index=False
+    )
     subset_plots(
         activity_df, subset_list=["marker"],
         save_dir=params["eval_dir"],
-        save_file="split_by_marker.png"
+        save_file="split_by_marker.png",
+        gt_key="activity",
+        pred_key="pred_activity",
     )
     subset_plots(
         activity_df, subset_list=["cell_type"],
         save_dir=params["eval_dir"],
-        save_file="split_by_marker.png"
+        save_file="split_by_cell_type.png",
+        gt_key="activity",
+        pred_key="pred_activity",
     )
     subset_plots(
-        activity_df, subset_list=["marker", "cell_type"],
+        activity_df, subset_list=["cell_type", "marker"],
         save_dir=params["eval_dir"],
-        save_file="split_by_marker_ct.png"
+        save_file="split_by_marker_ct.png",
+        gt_key="activity",
+        pred_key="pred_activity",
     )

--- a/cell_classification/metrics.py
+++ b/cell_classification/metrics.py
@@ -6,13 +6,10 @@ import os
 from sklearn.metrics import roc_curve, auc, confusion_matrix
 from model_builder import ModelBuilder
 import numpy as np
-from tqdm import tqdm
-from plot_utils import plot_average_roc, plot_metrics_against_threshold
 import toml
 from copy import deepcopy
 from joblib import Parallel, delayed
 import pandas as pd
-import tables
 
 
 def load_model_and_val_data(params):
@@ -66,6 +63,35 @@ def calc_roc(pred_list, gt_key="marker_activity_mask", pred_key="prediction", ce
     return roc
 
 
+def calc_scores(gt, pred, threshold):
+    """Calculate scores for a given threshold
+    Args:
+        gt (np.array):
+            ground truth labels
+        pred (np.array):
+            predictions
+        threshold (float):
+            threshold for predictions
+    Returns:
+        scores (dict):
+            dictionary containing scores
+    """
+    # exclude masked out regions from metric calculation
+    gt = gt[gt < 2]
+    pred = pred[gt < 2]
+    tn, fp, fn, tp = confusion_matrix(
+        y_true=gt, y_pred=(pred >= threshold).astype(int), labels=[0, 1]
+    ).ravel()
+    metrics = {
+        "tp": tp, "tn": tn, "fp": fp, "fn": fn,
+        "accuracy": (tp + tn) / (tp + tn + fp + fn + 1e-8),
+        "precision": tp / (tp + fp + 1e-8),
+        "recall": tp / (tp + fn + 1e-8),
+        "f1_score": 2 * tp / (2 * tp + fp + fn + 1e-8),
+    }
+    return metrics
+
+
 def calc_metrics(
     pred_list, gt_key="marker_activity_mask", pred_key="prediction", cell_level=False
 ):
@@ -82,19 +108,14 @@ def calc_metrics(
             dictionary containing metrics averaged over all samples
     """
     metrics_dict = {
-        "accuracy": [],
-        "precision": [],
-        "recall": [],
-        "f1_score": [],
-        "tp": [],
-        "tn": [],
-        "fp": [],
-        "fn": [],
+        "accuracy": [], "precision": [], "recall": [], "f1_score": [], "tp": [], "tn": [],
+        "fp": [], "fn": [],
     }
 
     def _calc_metrics(threshold):
         """Helper function to calculate metrics for a given threshold in parallel"""
         metrics = deepcopy(metrics_dict)
+
         for sample in pred_list:
             if cell_level:
                 df = sample["activity_df"]
@@ -106,18 +127,10 @@ def calc_metrics(
                 pred = sample[pred_key][foreground].flatten()
             if gt.size == 0:
                 continue
-            tn, fp, fn, tp = confusion_matrix(
-                y_true=gt.clip(0, 1), y_pred=(pred >= threshold).astype(int), labels=[0, 1]
-            ).ravel()
-            metrics["tp"].append(tp)
-            metrics["tn"].append(tn)
-            metrics["fp"].append(fp)
-            metrics["fn"].append(fn)
-            metrics["accuracy"].append((tp + tn) / (tp + tn + fp + fn + 1e-8))
-            metrics["precision"].append(tp / (tp + fp + 1e-8))
-            metrics["recall"].append(tp / (tp + fn + 1e-8))
-            metrics["f1_score"].append(2 * tp / (2 * tp + fp + fn + 1e-8))
-        metrics["threshold"] = threshold
+            scores = calc_scores(gt, pred, threshold)
+            for key in scores.keys():
+                metrics[key].append(scores[key])
+            metrics["threshold"] = threshold
         for key in ["dataset", "imaging_platform", "marker"]:
             metrics[key] = sample[key]
         return metrics

--- a/cell_classification/metrics_test.py
+++ b/cell_classification/metrics_test.py
@@ -5,16 +5,27 @@ import tempfile
 import toml
 import os
 from metrics import calc_roc, calc_metrics, average_roc, HDF5Loader
-
 import numpy as np
 import pandas as pd
 
 
 def make_pred_list():
     pred_list = []
-    for _ in range(10):
+    for i in range(10):
         instance_mask = np.random.randint(0, 10, size=(256, 256, 1))
         binary_mask = (instance_mask > 0).astype(np.uint8)
+        activity_df = pd.DataFrame(
+            {
+                "labels": np.array([1, 2, 5, 7, 9, 11], dtype=np.uint16),
+                "activity": [1, 0, 0, 0, 0, 1],
+                "cell_type": ["T cell", "B cell", "T cell", "B cell", "T cell", "B cell"],
+                "sample": [str(i)]*6,
+                "imaging_platform": ["test"]*6,
+                "dataset": ["test"]*6,
+                "marker": ["CD4"]*6 if i % 2 == 0 else "CD8",
+                "prediction": np.random.rand(6),
+            }
+        )
         pred_list.append(
             {
                 "marker_activity_mask": np.random.randint(0, 2, (256, 256, 1))*binary_mask,
@@ -22,6 +33,7 @@ def make_pred_list():
                 "instance_mask": instance_mask,
                 "binary_mask": binary_mask,
                 "dataset": "test", "imaging_platform": "test", "marker": "test",
+                "activity_df": activity_df,
             }
         )
     pred_list[-1]["marker_activity_mask"] = np.zeros((256, 256, 1))

--- a/cell_classification/metrics_test.py
+++ b/cell_classification/metrics_test.py
@@ -32,7 +32,8 @@ def make_pred_list():
                 "prediction": np.random.rand(256, 256, 1),
                 "instance_mask": instance_mask,
                 "binary_mask": binary_mask,
-                "dataset": "test", "imaging_platform": "test", "marker": "test",
+                "dataset": "test", "imaging_platform": "test",
+                "marker": "CD4" if i % 2 == 0 else "CD8",
                 "activity_df": activity_df,
             }
         )
@@ -55,8 +56,8 @@ def test_calc_metrics():
     pred_list = make_pred_list()
     avg_metrics = calc_metrics(pred_list)
     keys = [
-        "accuracy", "precision", "recall", "f1_score", "tp", "tn", "fp", "fn", "dataset",
-        "imaging_platform", "marker", "threshold",
+        "accuracy", "precision", "recall", "specificity", "f1_score", "tp", "tn", "fp", "fn",
+        "dataset", "imaging_platform", "marker", "threshold",
     ]
 
     # check if avg_metrics has the right keys

--- a/cell_classification/plot_utils.py
+++ b/cell_classification/plot_utils.py
@@ -199,10 +199,11 @@ def collapse_activity_dfs(pred_list):
         collapsed_df (pd.DataFrame):
             collapsed activity dataframe
     """
-    collapsed_df = pd.DataFrame()
+    collapse_list = []
     for sample in pred_list:
         sample["activity_df"]["marker"] = [sample["marker"]] * len(sample["activity_df"])
-        collapsed_df = pd.concat([collapsed_df, sample["activity_df"]])
+        collapse_list.append(sample["activity_df"])
+    collapsed_df = pd.concat(collapse_list)
     return collapsed_df
 
 

--- a/cell_classification/plot_utils.py
+++ b/cell_classification/plot_utils.py
@@ -7,8 +7,10 @@ from segmentation_data_prep import parse_dict, feature_description
 import tensorflow as tf
 from skimage.segmentation import find_boundaries
 import numpy as np
+import pandas as pd
 import argparse
 from tqdm import tqdm
+from metrics import calc_scores
 
 
 def segmentation_to_boundaries(labels):
@@ -177,12 +179,111 @@ def plot_metrics_against_threshold(
     """
     for key in metric_keys:
         plt.plot(metric_dict[threshold_key], metric_dict[key], label=key)
-    plt.xlabel("Threshold")
-    plt.ylabel("Metric")
-    plt.legend()
+        plt.xlabel("Threshold")
+        plt.ylabel("Metric")
+        plt.legend()
     if save_dir:
         os.makedirs(save_dir, exist_ok=True)
         plt.savefig(os.path.join(save_dir, save_file), dpi=dpi)
+    else:
+        plt.show()
+    plt.close()
+
+
+def collapse_activity_dfs(pred_list):
+    """Collapse activity dataframes
+    Args:
+        pred_list (list):
+            list of dictionaries containing activity dataframes
+    Returns:
+        collapsed_df (pd.DataFrame):
+            collapsed activity dataframe
+    """
+    collapsed_df = pd.DataFrame()
+    for sample in pred_list:
+        collapsed_df = pd.concat([collapsed_df, sample["activity_df"]])
+    return collapsed_df
+
+
+def subset_activity_df(activity_df, subset_dict):
+    """Subset predictions by marker
+    Args:
+        activity_df (pd.DataFrame):
+            activity dataframe
+        subset_dict (dict):
+            dictionary mapping activity_df colnames to values in this column to subset
+    Returns:
+        subset_df (pd.DataFrame):
+            subsetted activity dataframe
+    """
+    subset_df = activity_df.copy()
+    for key, value in subset_dict.items():
+        subset_df = subset_df[subset_df[key] == value]
+    return subset_df
+
+
+def subset_plots(activity_df, subset_list, save_dir=None, save_file=None, dpi=160):
+    """
+    Plot the activity of each marker in the subset_list
+    Args:
+        activity_df (pd.DataFrame):
+            A dataframe containing the activity of each marker
+        subset_list (list):
+            A list of markers you want to plot
+        save_dir (str):
+            If specified, a directory where we will save the plot
+        save_file (str):
+            If save_dir specified, specify a file name you wish to save to.
+            Ignored if save_dir is None
+        dpi (int):
+            The resolution of the image to save, ignored if save_dir is None
+    """
+    # prepare subset_uniques
+    subset_uniques = {}
+    for subset in subset_list:
+        subset_uniques[subset] = np.unique(getattr(activity_df, subset)).tolist()
+
+    # prepare plot grid
+    ndim = len(subset_list)
+    if ndim == 1:
+        plot_dim = [np.ceil(np.sqrt(len(subset_uniques[subset])))]*2
+    elif ndim > 1:
+        plot_dim = [len(item) for item in subset_uniques.items()]
+    plot_dim = [int(item) for item in plot_dim]
+    fig, ax = plt.subplots(plot_dim[0], plot_dim[1], figsize=(plot_dim[0]*2, plot_dim[1]*2))
+    for i in range(plot_dim[0]):
+        for j in range(plot_dim[1]):
+            key = list(subset_uniques.keys())[0]
+            if ndim == 1:
+                if i + j < len(subset_uniques[key]):
+                    subset_dict = {key: subset_uniques[key][i + j]}
+                else:
+                    break
+            else:
+                subset_dict = {key: subset_uniques[key][i] for key in subset_uniques.keys()}
+            df = subset_activity_df(activity_df, subset_dict)
+            thresholds = np.linspace(0.01, 1, 50)
+            metrics = [calc_scores(df["activity"], df["prediction"], i) for i in thresholds]
+            metric_dict = {
+                "threshold": thresholds,
+                "precision": [np.mean(i["precision"]) for i in metrics],
+                "recall": [np.mean(i["recall"]) for i in metrics],
+                "f1_score": [np.mean(i["f1_score"]) for i in metrics],
+            }
+            threshold_key = "threshold"
+            metric_keys = ["precision", "recall", "f1_score"]
+            for key in metric_keys:
+                ax[i, j].set_title(
+                    "".join([str(s[0]) + ": " + str(s[1]) + " " for s in subset_dict.items()])
+                )
+                ax[i, j].plot(metric_dict[threshold_key], metric_dict[key], label=key)
+                ax[i, j].set_xlabel("Threshold")
+                ax[i, j].set_ylabel("Metric")
+                ax[i, j].legend()
+    if save_dir:
+        os.makedirs(save_dir, exist_ok=True)
+        plt.savefig(os.path.join(save_dir, save_file), dpi=dpi)
+        plt.close()
     else:
         plt.show()
     plt.close()


### PR DESCRIPTION
**What is the purpose of this PR?**

This PR closes #23 . It contains code to prepare facet plots for arbitrary subsets of the cell-level predictions to get a clearer picture of error cases.

**How did you implement your changes**

I added functions `collapse_activity_dfs`, `subset_activity_df` and `subset_plots` to plot_utils.py and changed `calc_metrics` so that it does not internally defines function `calc_scores`, instead `calc_scores` is defined as a normal function so that I can get imported by `subset_plots`. 

**Remaining issues**

None
