### PR TITLE
Added segmentation_naming_convention function to segmentation_data_prep

### DIFF
--- a/cell_classification/prepare_data_script.py
+++ b/cell_classification/prepare_data_script.py
@@ -1,26 +1,35 @@
 import os
 from segmentation_data_prep import SegmentationTFRecords
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 
-os.listdir()
+
+def naming_convention(fname):
+    return os.path.join(
+        "C:/TONIC_Cohort/segmentation_data/deepcell_output", fname + "_feature_0.tif"
+    )
+
+
 data_prep = SegmentationTFRecords(
-    data_dir=os.path.normpath("C:/Users/lorenz/Downloads/Lorenz_example_data/mantis_directory"),
+    data_dir=os.path.normpath("C:/TONIC_Cohort/image_data/samples"),
     cell_table_path=os.path.normpath(
-        "C:/Users/lorenz/Downloads/Lorenz_example_data/cell_table.csv"
+        "C:/TONIC_Cohort/combined_cell_table_normalized_cell_labels_updated.csv"
     ),
     conversion_matrix_path=os.path.normpath(
-        "C:/Users/lorenz/Downloads/Lorenz_example_data/conversion_matrix.csv"
+        "C:/TONIC_Cohort/TONIC_conversion_matrix.csv"
     ),
     imaging_platform="MIBI",
-    dataset="TNBC",
+    dataset="TONIC",
     tile_size=[256, 256],
     stride=[240, 240],
-    tf_record_path=os.path.normpath("C:/Users/lorenz/Downloads/Lorenz_example_data"),
-    selected_markers=["CD8"],
-    normalization_dict_path=None,
+    tf_record_path=os.path.normpath("C:/Users/lorenz/Desktop/angelo_lab/TONIC"),
+    normalization_dict_path=os.path.normpath(
+        "C:/Users/lorenz/Desktop/angelo_lab/TONIC/normalization_dict.json"
+    ),
     normalization_quantile=0.99,
-    cell_type_key="cluster_labels",
-    sample_key="SampleID",
+    cell_type_key="cell_meta_cluster",
+    sample_key="fov",
     segmentation_fname="cell_segmentation",
+    segmentation_naming_convention=naming_convention,
     segment_label_key="label",
 )
 

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 import json
 from utils import verify_in_list, list_folders, validate_paths
 import copy
+import multiprocessing as mp
 
 
 class SegmentationTFRecords:
@@ -136,12 +137,11 @@ class SegmentationTFRecords:
                 The marker activity for the given labels, 1 if the marker is active, 0
                 otherwise and -1 if the marker is not specific enough to be considered active
         """
-        sample_subset = self.cell_type_table[self.cell_type_table[self.sample_key] == sample_name]
-        cell_types = sample_subset[self.cell_type_key].values
+        cell_types = self.sample_subset[self.cell_type_key].str.lower().values
 
         df = pd.DataFrame(
             {
-                "labels": sample_subset[self.segment_label_key],
+                "labels": self.sample_subset[self.segment_label_key],
                 "activity": conversion_matrix.loc[cell_types, marker].values,
                 "cell_type": cell_types,
             }
@@ -162,9 +162,13 @@ class SegmentationTFRecords:
             np.array:
                 The marker activity mask
         """
-        out_mask = np.zeros_like(instance_mask)
-        for label, activity in zip(marker_activity.labels, marker_activity.activity):
-            out_mask[instance_mask == label] = activity
+        out_mask = np.zeros_like(instance_mask, dtype=np.uint8)
+        positives = marker_activity.labels[marker_activity.activity == 1].values.tolist()
+        undecided = marker_activity.labels[marker_activity.activity == 2].values.tolist()
+        positives = np.isin(instance_mask, positives)
+        negatives = np.isin(instance_mask, undecided)
+        out_mask[positives] = 1
+        out_mask[negatives] = 2
         out_mask[binary_mask == 0] = 0
         return out_mask
 
@@ -186,17 +190,16 @@ class SegmentationTFRecords:
         mplex_img = self.get_image(data_folder, marker).astype(np.float32)
         mplex_img /= self.normalization_dict[marker]
         mplex_img = mplex_img.clip(0, 1)
-        binary_mask, instance_mask = self.get_inst_binary_masks(data_folder)
-        fov = os.path.split(data_folder)[-1]
+        fov = os.path.basename(data_folder)
         # get the cell types and marker activity mask
         marker_activity, cell_types = self.get_marker_activity(fov, self.conversion_matrix, marker)
         marker_activity_mask = self.get_marker_activity_mask(
-            instance_mask, binary_mask, marker_activity
+            self.instance_mask, self.binary_mask, marker_activity
         )
         return {
             "mplex_img": mplex_img.astype(np.float32),
-            "binary_mask": binary_mask.astype(np.uint8),
-            "instance_mask": instance_mask.astype(np.uint16),
+            "binary_mask": self.binary_mask.astype(np.uint8),
+            "instance_mask": self.instance_mask.astype(np.uint16),
             "imaging_platform": self.imaging_platform,
             "marker_activity_mask": marker_activity_mask.astype(np.uint8),
             "dataset": self.dataset,
@@ -233,8 +236,8 @@ class SegmentationTFRecords:
                 example[key] = np.pad(
                     example[key],
                     ((0, example[key].shape[0] % self.tile_size[0]),
-                     (0, example[key].shape[1] % self.tile_size[1]),
-                     (0, 0)),
+                        (0, example[key].shape[1] % self.tile_size[1]),
+                        (0, 0)),
                     mode="constant",
                 )
             res = np.lib.stride_tricks.sliding_window_view(
@@ -259,7 +262,7 @@ class SegmentationTFRecords:
             # subset marker_activity to the labels that are present in the tile
             label_subset = np.unique(example_out["instance_mask"]).astype(np.uint16).tolist()
             example_out["activity_df"] = example["activity_df"].loc[
-                [True if i in label_subset else False for i in example["activity_df"].labels]
+                example["activity_df"].labels.isin(label_subset)
             ]
             example_list.append(example_out)
 
@@ -271,14 +274,14 @@ class SegmentationTFRecords:
         os.makedirs(self.tf_record_path, exist_ok=True)
 
         # DATA DIR
-        validate_paths(self.data_dir)
+        validate_paths(self.data_dir, data_prefix=False)
         self.data_folders = [
             os.path.join(self.data_dir, folder) for folder in list_folders(self.data_dir)
         ]
 
         # CONVERSION MATRIX
         # read the file
-        validate_paths(self.conversion_matrix_path)
+        validate_paths(self.conversion_matrix_path, data_prefix=False)
         self.conversion_matrix = pd.read_csv(self.conversion_matrix_path, index_col=0)
 
         # check if markers were selected or take all markers from conversion matrix
@@ -308,7 +311,7 @@ class SegmentationTFRecords:
         # NORMALIZATION DICT
         # load or construct normalization dict
         if self.normalization_dict_path:
-            validate_paths(self.normalization_dict_path)
+            validate_paths(self.normalization_dict_path, data_prefix=False)
             self.normalization_dict = json.load(open(self.normalization_dict_path, "r"))
 
             # check if selected markers are in normalization dict
@@ -330,6 +333,9 @@ class SegmentationTFRecords:
         # CELL TYPE TABLE
         # load cell_types.csv
         self.cell_type_table = pd.read_csv(self.cell_table_path)
+        self.cell_type_table.drop(self.cell_type_table.columns.difference([
+            self.cell_type_key, self.segment_label_key, self.sample_key,
+        ]), 1, inplace=True)
 
         # check if cell_type_key is in cell_type_table
         if self.cell_type_key not in self.cell_type_table.columns:
@@ -352,8 +358,6 @@ class SegmentationTFRecords:
 
         # make cell_types lowercase to make matching easier
         self.conversion_matrix.index = self.conversion_matrix.index.str.lower()
-        self.cell_type_table[self.cell_type_key] = self.cell_type_table[self.cell_type_key] \
-            .str.lower()
 
     def make_tf_record(self):
         """Iterates through the data_folders and loads, transforms and
@@ -374,8 +378,13 @@ class SegmentationTFRecords:
 
         # iterate through data_folders and markers to prepare and tile examples
         print("Preparing examples...")
-        for data_folder in tqdm(self.data_folders):
-            for marker in self.selected_markers:
+        for data_folder in self.data_folders:
+            print(os.path.basename(data_folder))
+            self.sample_subset = self.cell_type_table[
+                self.cell_type_table[self.sample_key] == os.path.basename(data_folder)
+            ]
+            self.binary_mask, self.instance_mask = self.get_inst_binary_masks(data_folder)
+            for marker in tqdm(self.selected_markers):
                 example = self.prepare_example(data_folder, marker)
                 if self.tile_size:
                     example_list = self.tile_example(example)
@@ -383,8 +392,8 @@ class SegmentationTFRecords:
                     example_list = [example]
 
                 # serialize and write examples to tfrecord
-                for example in example_list:
-                    example_serialized = self.serialize_example(example)
+                for ex in example_list:
+                    example_serialized = self.serialize_example(ex)
                     self.writer.write(example_serialized)
         self.writer.close()
         delattr(self, "writer")
@@ -417,13 +426,13 @@ class SegmentationTFRecords:
             elif type(example[key]) in [pd.DataFrame, pd.Series]:
                 string_example[key] = tf.train.Feature(
                     int64_list=tf.train.Int64List(
-                        value=tf.strings.unicode_decode(example[key].to_json(), "UTF-8")
+                        value=tf.strings.unicode_decode(example[key].to_json(), "UTF-8").numpy()
                     )
                 )
             elif type(example[key]) == str:
                 string_example[key] = tf.train.Feature(
                     int64_list=tf.train.Int64List(
-                        value=tf.strings.unicode_decode(example[key], "UTF-8")
+                        value=tf.strings.unicode_decode(example[key], "UTF-8").numpy()
                     )
                 )
         #


### PR DESCRIPTION
**What is the purpose of this PR?**

This PR adds a way for the dataset constructor `SegmentationTFRecords` to load segmentation tiffs from other folders than the sample folder or with weird naming conventions. 

**How did you implement your changes**

You can pass a function to SegmentationTFRecords.segmentation_naming_convention that takes in the name of the sample_folder and returns the path to the segmentation tiff for that sample.

**Remaining issues**

None
