### PR TITLE
Added manual training loop to capture training data within epochs

### DIFF
--- a/cell_classification/configs/params.toml
+++ b/cell_classification/configs/params.toml
@@ -1,7 +1,7 @@
 record_path = "C:/Users/lorenz/Desktop/angelo_lab/MIBI_test/TNBC_CD45.tfrecord"
 path = "C:/Users/lorenz/OneDrive/Desktop/angelo_lab/"
 experiment = "test"
-num_epochs = 10
+num_steps = 20
 lr = 1e-3
 backbone = "resnet50"
 input_shape = [256,256,2]
@@ -26,7 +26,6 @@ contrast_prob = 0.5
 contrast_min = 0.8
 contrast_max = 1.2
 batch_size = 4
-steps_per_epoch = 100
 loss_fn = "BinaryCrossentropy"
 loss_selective_masking = true
 [loss_kwargs]

--- a/cell_classification/metrics_test.py
+++ b/cell_classification/metrics_test.py
@@ -99,6 +99,8 @@ def test_HDF5Generator():
         params["experiment"] = "test"
         params["num_epochs"] = 0
         params["num_validation"] = 2
+        params["snap_steps"] = 10
+        params["val_steps"] = 10
         model = ModelBuilder(params)
         model.train()
         model.params["eval"] = True

--- a/cell_classification/model_builder_test.py
+++ b/cell_classification/model_builder_test.py
@@ -8,6 +8,8 @@ import toml
 from model_builder import ModelBuilder
 import h5py
 
+tf.config.run_functions_eagerly(True)
+
 
 def test_prep_loss():
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -37,7 +39,7 @@ def test_prep_data():
         params["record_path"] = tf_record_path
         params["path"] = temp_dir
         params["experiment"] = "test"
-        params["num_epochs"] = 1
+        params["num_steps"] = 20
         params["num_validation"] = 2
         params["batch_size"] = 2
         trainer = ModelBuilder(params)
@@ -45,11 +47,10 @@ def test_prep_data():
 
         # check if correct number of samples per batch is returned
         trainer.validation_dataset = trainer.validation_dataset.map(
-                trainer.prep_batches, num_parallel_calls=tf.data.AUTOTUNE
+            trainer.prep_batches, num_parallel_calls=tf.data.AUTOTUNE
         )
         assert next(iter(trainer.train_dataset))[0].shape[0] == params["batch_size"]
-        assert next(iter(trainer.validation_dataset))[0].shape[0] == \
-            params["batch_size"]
+        assert next(iter(trainer.validation_dataset))[0].shape[0] == params["batch_size"]
 
         # check if samples only contains two files (inputs, targets)
         assert len(next(iter(trainer.train_dataset))) == 2
@@ -60,11 +61,9 @@ def test_prep_data():
         trainer.prep_data()
         val_dset = iter(trainer.validation_dataset)
         val_batch = next(val_dset)
-        assert set(val_batch.keys()) == set(
-            [
+        assert set(val_batch.keys()) == set([
                 "mplex_img", "binary_mask", "instance_mask", "folder_name", "marker", "dataset",
-                "imaging_platform", "marker_activity_mask", "activity_df",
-            ]
+                "imaging_platform", "marker_activity_mask", "activity_df"]
         )
 
 
@@ -81,18 +80,41 @@ def test_prep_model():
         assert isinstance(trainer.optimizer, tf.keras.optimizers.Optimizer)
 
         # check if all the directories were created
-        assert os.path.exists(trainer.params['log_dir'])
-        assert os.path.exists(trainer.params['model_dir'])
-
-        # check if callbacks were created
-        assert isinstance(trainer.train_callbacks[0], tf.keras.callbacks.ModelCheckpoint)
-        assert isinstance(trainer.train_callbacks[1], tf.keras.callbacks.TensorBoard)
-        assert isinstance(trainer.train_callbacks[2], tf.keras.callbacks.LearningRateScheduler)
+        assert os.path.exists(trainer.params["log_dir"])
+        assert os.path.exists(trainer.params["model_dir"])
 
         # check if model path is taken from params.toml if it exists
         trainer.params["model_path"] = os.path.join(temp_dir, "test_dir", "test.h5")
         trainer.prep_model()
         assert trainer.params["model_path"] == os.path.join(temp_dir, "test_dir", "test.h5")
+
+
+def test_train_step():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        data_prep, _, _, _ = prep_object_and_inputs(temp_dir)
+        data_prep.tf_record_path = temp_dir
+        data_prep.make_tf_record()
+        tf_record_path = os.path.join(data_prep.tf_record_path, data_prep.dataset + ".tfrecord")
+        params = toml.load("cell_classification/configs/params.toml")
+        params["record_path"] = tf_record_path
+        params["path"] = temp_dir
+        params["experiment"] = "test"
+        params["num_steps"] = 20
+        params["num_validation"] = 2
+        params["batch_size"] = 2
+        params["test"] = True
+        params["weight_decay"] = 1e-4
+        params["snap_steps"] = 5
+        params["val_steps"] = 5
+        trainer = ModelBuilder(params)
+        trainer.prep_data()
+        trainer.prep_model()
+        x, y = next(iter(trainer.train_dataset))
+
+        # check if train_step returns correct loss
+        loss = trainer.train_step(trainer.model, x, y)
+        assert loss.dtype == tf.float32
+        assert loss > 0
 
 
 def test_train():
@@ -105,45 +127,39 @@ def test_train():
         params["record_path"] = tf_record_path
         params["path"] = temp_dir
         params["experiment"] = "test"
-        params["num_epochs"] = 2
+        params["num_steps"] = 20
         params["num_validation"] = 2
         params["batch_size"] = 2
         params["test"] = True
         params["weight_decay"] = 1e-4
-        params["steps_per_epoch"] = 5000
+        params["snap_steps"] = 5
+        params["val_steps"] = 5
 
         trainer = ModelBuilder(params)
         trainer.train()
 
-        # check if loss_history is of type tf.keras.callbacks.History
-        assert isinstance(trainer.loss_history, tf.keras.callbacks.History)
-
-        # check if model is trained for correct number of epochs
-        assert len(trainer.loss_history.history["loss"]) == params["num_epochs"]
-
         # check if loss history is written to file
-        assert "tfevents" in os.listdir(os.path.join(trainer.params['log_dir'], "train"))[0]
-        assert "tfevents" in os.listdir(os.path.join(trainer.params['log_dir'], "validation"))[0]
+        assert "tfevents" in os.listdir(trainer.params["log_dir"])[0]
 
         # check if model checkpoint is written to file
-        assert os.path.split(trainer.params['model_path'])[-1] in os.listdir(
-            trainer.params['model_dir']
+        assert os.path.split(trainer.params["model_path"])[-1] in os.listdir(
+            trainer.params["model_dir"]
         )
 
         # check params.toml is dumped to file and contains the created paths
-        assert "params.toml" in os.listdir(trainer.params['model_dir'])
-        loaded_params = toml.load(os.path.join(trainer.params['model_dir'], "params.toml"))
+        assert "params.toml" in os.listdir(trainer.params["model_dir"])
+        loaded_params = toml.load(os.path.join(trainer.params["model_dir"], "params.toml"))
         for key in ["model_dir", "log_dir", "model_path"]:
             assert key in list(loaded_params.keys())
 
         # check if model is saved to file
-        assert os.path.split(trainer.params['model_path'])[-1] in os.listdir(
-            trainer.params['model_dir']
+        assert os.path.split(trainer.params["model_path"])[-1] in os.listdir(
+            trainer.params["model_dir"]
         )
 
         # check if model can be loaded from file
         trainer.model = None
-        trainer.load_model(trainer.params['model_path'])
+        trainer.load_model(trainer.params["model_path"])
         assert isinstance(trainer.model, tf.keras.Model)
 
 
@@ -157,10 +173,13 @@ def test_predict():
         params["record_path"] = tf_record_path
         params["path"] = temp_dir
         params["experiment"] = "test"
-        params["num_epochs"] = 2
+        params["num_steps"] = 20
         params["num_validation"] = 2
         params["batch_size"] = 2
         params["test"] = True
+        params["snap_steps"] = 5000
+        params["val_steps"] = 5000
+
         trainer = ModelBuilder(params)
         trainer.train()
         val_dset = trainer.validation_dataset.map(
@@ -190,9 +209,11 @@ def test_predict_dataset():
         params["record_path"] = tf_record_path
         params["path"] = temp_dir
         params["experiment"] = "test"
-        params["num_epochs"] = 2
+        params["num_steps"] = 2
         params["num_validation"] = 2
         params["batch_size"] = 2
+        params["snap_steps"] = 5000
+        params["val_steps"] = 5000
         trainer = ModelBuilder(params)
         trainer.train()
         val_dset = trainer.validation_dataset
@@ -208,11 +229,11 @@ def test_predict_dataset():
         single_example_list = trainer.predict_dataset(val_dset, save_predictions=True)
         params = trainer.params
         for i in range(params["num_validation"]):
-            assert str(i).zfill(4)+'_pred.hdf' in list(os.listdir(params['eval_dir']))
+            assert str(i).zfill(4) + "_pred.hdf" in list(os.listdir(params["eval_dir"]))
 
-        with h5py.File(os.path.join(params['eval_dir'], str(0).zfill(4)+'_pred.hdf'), 'r') as f:
-            assert f['prediction'].shape == (256, 256, 1)
-            assert f['marker_activity_mask'].shape == (256, 256, 1)
+        with h5py.File(os.path.join(params["eval_dir"], str(0).zfill(4) + "_pred.hdf"), "r") as f:
+            assert f["prediction"].shape == (256, 256, 1)
+            assert f["marker_activity_mask"].shape == (256, 256, 1)
             assert set(list(f.keys())) == set(list(single_example_list[0].keys()))
 
 
@@ -226,7 +247,7 @@ def test_add_weight_decay():
         params["record_path"] = tf_record_path
         params["path"] = temp_dir
         params["experiment"] = "test"
-        params["num_epochs"] = 2
+        params["num_steps"] = 20
         params["num_validation"] = 2
         params["batch_size"] = 2
         params["test"] = True


### PR DESCRIPTION
**What is the purpose of this PR?**

I replaced the `keras.fit` training loop with a custom training loop in `model_builder.py` in order to write out snapshots and training/validation loss every n steps instead of every n epochs. 

**How did you implement your changes**

Added `train_step()` and `distributed_train_step()` to `ModelBuilder` and changed `train()`

**Remaining issues**

I need to do further tests to see if everything works fine for multi-GPU training. At the moment the validation loss is weirdly scaled for multi - gpu training.