### PR TITLE
Added promix naive loss masking scheme

### DIFF
--- a/cell_classification/configs/params.toml
+++ b/cell_classification/configs/params.toml
@@ -30,6 +30,7 @@ loss_fn = "BinaryCrossentropy"
 loss_selective_masking = true
 quantile = 0.3
 confidence_thresholds = [0.1, 0.9]
+ema = 0.01
 [loss_kwargs]
 from_logits = false
 label_smoothing = 0.1

--- a/cell_classification/configs/params.toml
+++ b/cell_classification/configs/params.toml
@@ -28,6 +28,8 @@ contrast_max = 1.2
 batch_size = 4
 loss_fn = "BinaryCrossentropy"
 loss_selective_masking = true
+quantile = 0.3
+confidence_thresholds = [0.1, 0.9]
 [loss_kwargs]
 from_logits = false
 label_smoothing = 0.1

--- a/cell_classification/metrics_test.py
+++ b/cell_classification/metrics_test.py
@@ -7,6 +7,7 @@ import os
 from metrics import calc_roc, calc_metrics, average_roc, HDF5Loader
 import numpy as np
 import pandas as pd
+import tensorflow as tf
 
 
 def make_pred_list():
@@ -97,17 +98,13 @@ def test_HDF5Generator():
         params["record_path"] = tf_record_path
         params["path"] = temp_dir
         params["experiment"] = "test"
-        params["num_epochs"] = 0
+        params["num_steps"] = 2
         params["num_validation"] = 2
-        params["snap_steps"] = 10
-        params["val_steps"] = 10
+        params["snap_steps"] = 100
+        params["val_steps"] = 100
         model = ModelBuilder(params)
         model.train()
-        model.params["eval"] = True
-        model.prep_data()
-        val_dset = iter(model.validation_dataset)
-
-        single_example_list = model.predict_dataset(val_dset, save_predictions=True)
+        model.predict_dataset(model.validation_dataset, save_predictions=True)
         generator = HDF5Loader(model.params['eval_dir'])
 
         # check if generator has the right number of items
@@ -116,4 +113,4 @@ def test_HDF5Generator():
         # check if generator returns the right items
         for sample in generator:
             assert isinstance(sample, dict)
-            assert set(list(sample.keys())) == set(list(single_example_list[0].keys()))
+            assert len(list(sample.keys())) == 11

--- a/cell_classification/promix_naive.py
+++ b/cell_classification/promix_naive.py
@@ -1,18 +1,18 @@
-from model_builder import ModelBuilder
-from segmentation_data_prep import parse_dict, feature_description
-from tensorflow.keras.optimizers import SGD, Adam
-from tensorflow.keras.callbacks import LearningRateScheduler
-from tensorflow.keras.optimizers.schedules import CosineDecay
 from deepcell.utils.train_utils import rate_scheduler, get_callbacks, count_gpus
-from semantic_head import create_semantic_head
+from segmentation_data_prep import parse_dict, feature_description
+from tensorflow.keras.optimizers.schedules import CosineDecay
+from tensorflow.keras.callbacks import LearningRateScheduler
 from deepcell.model_zoo.panopticnet import PanopticNet
+from tensorflow.keras.optimizers import SGD, Adam
+from semantic_head import create_semantic_head
+from model_builder import ModelBuilder
 import tensorflow as tf
+from time import time
+from tqdm import tqdm
 import pandas as pd
 import numpy as np
 import toml
 import os
-from time import time
-
 
 
 class PromixNaive(ModelBuilder):
@@ -24,11 +24,10 @@ class PromixNaive(ModelBuilder):
         self.quantile = self.params["quantile"]
         self.class_wise_loss_quantiles = {}
 
-
-
     def matched_high_confidence_selection_thresholds(self):
+        """Returns a dictionary with the thresholds for the high confidence selection"""
         neg_thresh, pos_thresh = self.params["confidence_thresholds"]
-        targets = tf.constant(np.array([[0,1]]).transpose())
+        targets = tf.constant(np.array([[0, 1]]).transpose())
         y_pred = tf.constant(np.array([[neg_thresh, pos_thresh]]).transpose())
         loss = self.loss_fn(targets, y_pred)
         return {"negative": loss.numpy()[0], "positive": loss.numpy()[1]}
@@ -39,7 +38,7 @@ class PromixNaive(ModelBuilder):
         dataset = tf.data.TFRecordDataset(self.params["record_path"])
         dataset = dataset.map(
             lambda x: tf.io.parse_single_example(x, feature_description),
-            num_parallel_calls=tf.data.AUTOTUNE
+            num_parallel_calls=tf.data.AUTOTUNE,
         )
         dataset = dataset.map(parse_dict, num_parallel_calls=tf.data.AUTOTUNE)
 
@@ -47,59 +46,17 @@ class PromixNaive(ModelBuilder):
         self.validation_dataset = dataset.take(self.params["num_validation"])
         self.train_dataset = dataset.skip(self.params["num_validation"])
 
-    def prep_model(self):
-        """Prepares the model for training"""
-        # prepare folders
-        self.params["model_dir"] = os.path.join(
-            os.path.normpath(self.params["path"]), self.params["experiment"]
+        # shuffle, batch and prefetch the training data
+        self.train_dataset = self.train_dataset.shuffle(self.params["shuffle_buffer_size"]).batch(
+            self.params["batch_size"]
         )
-        self.params["log_dir"] = os.path.join(self.params["model_dir"], "logs", str(int(time())))
-        os.makedirs(self.params["model_dir"], exist_ok=True)
-        os.makedirs(self.params["log_dir"], exist_ok=True)
-        if "model_path" not in self.params.keys() or self.params["model_path"] is None:
-            self.params["model_path"] = os.path.join(
-                self.params["model_dir"], "{}.h5".format(self.params["experiment"])
-            )
-        self.params["loss_path"] = os.path.join(
-            self.params["model_dir"], "{}.npz".format(self.params["experiment"])
+        self.train_dataset = self.train_dataset.prefetch(tf.data.AUTOTUNE)
+
+        self.validation_dataset = self.validation_dataset.batch(
+            self.params["batch_size"] * np.max([self.num_gpus, 1])
         )
 
-        # initialize optimizer and lr scheduler
-        # replace with AdamW when available
-        self.lr_sched = CosineDecay(
-            initial_learning_rate=self.params["lr"],
-            decay_steps=self.params["num_steps"],
-            alpha=1e-6,
-        )
-        self.optimizer = Adam(learning_rate=self.lr_sched, clipnorm=0.001)
-
-        # initialize model
-        if "test" in self.params.keys() and self.params["test"]:
-            self.model = tf.keras.Sequential(
-                [tf.keras.layers.Conv2D(
-                        1, (3, 3), input_shape=self.params["input_shape"], padding="same",
-                        name="semantic_head", activation="sigmoid", data_format="channels_last",
-                    )]
-            )
-        else:
-            self.model = PanopticNet(
-                backbone=self.params["backbone"], input_shape=self.params["input_shape"],
-                norm_method="std", num_semantic_classes=self.params["classes"],
-                create_semantic_head=create_semantic_head,
-            )
-
-        loss = {}
-        # Give losses for all of the semantic heads
-        for layer in self.model.layers:
-            if layer.name.startswith("semantic_"):
-                loss[layer.name] = self.prep_loss()
-
-        if "weight_decay" in self.params.keys():
-            self.add_weight_decay()
-        self.model.compile(loss=loss, optimizer=self.optimizer)
-
-
-    @staticmethod
+    @staticmethod  # with @tf.function 0.4 s/batch, without 0.15 s/batch on notebook
     def train_step(model, optimizer, loss_fn, aug_fn, loss_mask, x, y_gt):
         """Performs a training step
         Args:
@@ -124,49 +81,70 @@ class PromixNaive(ModelBuilder):
 
     def train(self):
         """Calls prep functions and starts training loops"""
+        print("Training on", self.num_gpus, "GPUs.")
+        # initialize data and model
         self.prep_data()
         self.prep_model()
         self.confidence_loss_thresholds = self.matched_high_confidence_selection_thresholds()
-        #
-        validation_dataset = self.validation_dataset.map(
-                self.prep_batches, num_parallel_calls=tf.data.AUTOTUNE
-        )
-        # shuffle, batch and augment the training data
-        self.train_dataset = self.train_dataset.shuffle(self.params["shuffle_buffer_size"]).batch(
-            self.params["batch_size"]
-        )
-        self.train_dataset = self.train_dataset.prefetch(tf.data.AUTOTUNE)
+        train_step = self.train_step
 
-        with open(os.path.join(self.params['model_dir'], "params.toml"), "w") as f:
+        with open(os.path.join(self.params["model_dir"], "params.toml"), "w") as f:
             toml.dump(self.params, f)
+        self.summary_writer = tf.summary.create_file_writer(self.params["log_dir"])
+        self.step = 0
+        self.val_loss_history = []
+        self.train_loss_tmp = []
         # train the model
-        for batch in self.train_dataset:
-            inputs, targets = self.prep_batches(batch)
-            y_pred = self.model(inputs, training=False)
-            loss_img = self.loss_fn(targets, y_pred)
-            # map over batch dimension
-            uniques, loss_per_cell = tf.map_fn(
-                self.reduce_to_cells, (loss_img, batch["instance_mask"]), infer_shape=False,
-                fn_output_signature=[
-                    tf.RaggedTensorSpec(shape=[None], dtype=tf.int32, ragged_rank=0),
-                    tf.RaggedTensorSpec(shape=[None], dtype=tf.float32, ragged_rank=0)
+        while self.step < self.params["num_steps"]:
+            for batch in tqdm(self.train_dataset):
+                # prepare loss mask with unaugmented batches
+                x, y = self.prep_batches(batch)
+                y_pred = self.model(x, training=False)
+                loss_img = self.loss_fn(y, y_pred)
+                uniques, loss_per_cell = tf.map_fn(
+                    self.reduce_to_cells,
+                    (loss_img, batch["instance_mask"]),
+                    infer_shape=False,
+                    fn_output_signature=[
+                        tf.RaggedTensorSpec(shape=[None], dtype=tf.int32, ragged_rank=0),
+                        tf.RaggedTensorSpec(shape=[None], dtype=tf.float32, ragged_rank=0),
+                    ],
+                )
+                batch["activity_df"] = [
+                    pd.read_json(df.decode()) for df in batch["activity_df"].numpy()
                 ]
-            )
-            batch["activity_df"] =  [pd.read_json(df.decode()) for df in batch["activity_df"].numpy()]
-            batch["activity_df"] = [df.merge(pd.DataFrame({
-                "labels": uniques[i].numpy(), "loss": loss_per_cell[i].numpy()}), on="labels")
-                for i, df in enumerate(batch["activity_df"])]
-            #
-            loss_mask = self.batchwise_loss_selection(
-                batch["activity_df"], batch["instance_mask"], batch["marker"]
-            )
-            loss_mask = tf.cast(loss_mask, tf.float32)
-            aug_fn = lambda x, y, z: (x, y, z)
-            loss = self.train_step(
-                self.model, self.optimizer, self.loss_fn, aug_fn, loss_mask, inputs,
-                targets
-            )
-            print(loss)
+                batch["activity_df"] = [
+                    df.merge(
+                        pd.DataFrame(
+                            {"labels": uniques[i].numpy(), "loss": loss_per_cell[i].numpy()}
+                        ),
+                        on="labels",
+                    )
+                    for i, df in enumerate(batch["activity_df"])
+                ]
+                #
+                loss_mask = self.batchwise_loss_selection(
+                    batch["activity_df"], batch["instance_mask"], batch["marker"]
+                )
+                loss_mask = tf.cast(loss_mask, tf.float32)
+                # augment batches and do train_step
+
+                def aug_fn(x, y, z):
+                    return (x, y, z)
+                train_loss = train_step(
+                    self.model, self.optimizer, self.loss_fn, aug_fn, loss_mask, x, y
+                )
+                self.train_loss_tmp.append(train_loss)
+                self.step += 1
+                self.tensorboard_callbacks(x, y)
+                if self.step > self.params["num_steps"]:
+                    break
+                # save loss_mask
+                if self.step % self.params["snap_steps"] == 0:
+                    with self.summary_writer.as_default():
+                        tf.summary.image(
+                            "loss_mask", tf.expand_dims(loss_mask, axis=-1), step=self.step
+                        )
 
     @staticmethod
     @tf.autograph.experimental.do_not_convert
@@ -180,7 +158,7 @@ class PromixNaive(ModelBuilder):
                 mean_per_cell (tf.Tensor): mean loss per cell, batch x num_cells 0-padded to 200
         """
         pred, instance_mask = tuple_in
-        instance_mask_flat = tf.cast(tf.reshape(instance_mask, -1), tf.int32) # b x (h*w)
+        instance_mask_flat = tf.cast(tf.reshape(instance_mask, -1), tf.int32)  # b x (h*w)
         pred_flat = tf.cast(tf.reshape(pred, -1), tf.float32)
         uniques, _ = tf.unique(instance_mask_flat)
         sort_order = tf.argsort(instance_mask_flat)
@@ -191,7 +169,7 @@ class PromixNaive(ModelBuilder):
         return [uniques, mean_per_cell]
 
     def batchwise_loss_selection(self, activity_df, instance_mask, marker):
-        """Selects the cells with the lowest loss for each class and runs 
+        """Selects the cells with the lowest loss for each class and runs
             matched_high_confidence_selection internally
         Args:
             activity_df (pd.DataFrame): dataframe with columns "labels", "activity" and "loss"
@@ -209,7 +187,7 @@ class PromixNaive(ModelBuilder):
             positive_df = df[df["activity"] == 1]
             negative_df = df[df["activity"] == 0]
             selected_subset = []
-            # matched high confidence selection
+            # loss selection methods
             selected_subset += self.class_wise_loss_selection(positive_df, negative_df, mark)
             selected_subset += self.matched_high_confidence_selection(positive_df, negative_df)
             selected_subset = pd.concat(selected_subset)
@@ -235,18 +213,26 @@ class PromixNaive(ModelBuilder):
             # add keys to dict if not present and set ema to 1 for initialization
             self.class_wise_loss_quantiles[mark] = {"positive": 1.0, "negative": 1.0}
             ema = 1.0
-        if positive_df.shape[0] >0:
-            self.class_wise_loss_quantiles[mark]["positive"] = \
-                self.class_wise_loss_quantiles[mark]["positive"] * \
-                (1 - ema) + np.quantile(positive_df.loss, self.quantile) * ema
+        if positive_df.shape[0] > 0:
+            self.class_wise_loss_quantiles[mark]["positive"] = (
+                self.class_wise_loss_quantiles[mark]["positive"] * (1 - ema)
+                + np.quantile(positive_df.loss, self.quantile) * ema
+            )
             selected_subset.append(
-                positive_df[positive_df["loss"] <= self.class_wise_loss_quantiles[mark]["positive"]])
-        if negative_df.shape[0] >0:
-            self.class_wise_loss_quantiles[mark]["negative"] = \
-                self.class_wise_loss_quantiles[mark]["negative"] * \
-                (1 - ema) + np.quantile(negative_df.loss, self.quantile) * ema
+                positive_df[
+                    positive_df["loss"] <= self.class_wise_loss_quantiles[mark]["positive"]
+                ]
+            )
+        if negative_df.shape[0] > 0:
+            self.class_wise_loss_quantiles[mark]["negative"] = (
+                self.class_wise_loss_quantiles[mark]["negative"] * (1 - ema)
+                + np.quantile(negative_df.loss, self.quantile) * ema
+            )
             selected_subset.append(
-                negative_df[negative_df["loss"] <= self.class_wise_loss_quantiles[mark]["negative"]])
+                negative_df[
+                    negative_df["loss"] <= self.class_wise_loss_quantiles[mark]["negative"]
+                ]
+            )
         return selected_subset
 
     def matched_high_confidence_selection(self, positive_df, negative_df):
@@ -255,13 +241,17 @@ class PromixNaive(ModelBuilder):
             positive_df (pd.DataFrame): dataframe with columns "labels", "activity" and "loss"
                 containing only GT positive cells
             negative_df (pd.DataFrame): dataframe with columns "labels", "activity" and "loss"
-                containing only GT negative cells            
+                containing only GT negative cells
         Returns:
             list: list of pd.DataFrame that contains the selected cells
         """
         selected_subset = []
         if positive_df.shape[0] > 0:
-            selected_subset.append(positive_df[positive_df.loss<self.confidence_loss_thresholds["positive"]])
+            selected_subset.append(
+                positive_df[positive_df.loss < self.confidence_loss_thresholds["positive"]]
+            )
         if negative_df.shape[0] > 0:
-            selected_subset.append(negative_df[negative_df.loss<self.confidence_loss_thresholds["negative"]])
+            selected_subset.append(
+                negative_df[negative_df.loss < self.confidence_loss_thresholds["negative"]]
+            )
         return selected_subset

--- a/cell_classification/promix_naive.py
+++ b/cell_classification/promix_naive.py
@@ -1,0 +1,267 @@
+from model_builder import ModelBuilder
+from segmentation_data_prep import parse_dict, feature_description
+from tensorflow.keras.optimizers import SGD, Adam
+from tensorflow.keras.callbacks import LearningRateScheduler
+from tensorflow.keras.optimizers.schedules import CosineDecay
+from deepcell.utils.train_utils import rate_scheduler, get_callbacks, count_gpus
+from semantic_head import create_semantic_head
+from deepcell.model_zoo.panopticnet import PanopticNet
+import tensorflow as tf
+import pandas as pd
+import numpy as np
+import toml
+import os
+from time import time
+
+
+
+class PromixNaive(ModelBuilder):
+    def __init__(self, params):
+        super().__init__(params)
+        self.params = params
+        self.num_gpus = count_gpus()
+        self.loss_fn = self.prep_loss()
+        self.quantile = self.params["quantile"]
+        self.class_wise_loss_quantiles = {}
+
+
+
+    def matched_high_confidence_selection_thresholds(self):
+        neg_thresh, pos_thresh = self.params["confidence_thresholds"]
+        targets = tf.constant(np.array([[0,1]]).transpose())
+        y_pred = tf.constant(np.array([[neg_thresh, pos_thresh]]).transpose())
+        loss = self.loss_fn(targets, y_pred)
+        return {"negative": loss.numpy()[0], "positive": loss.numpy()[1]}
+
+    def prep_data(self):
+        """Prepares training and validation data"""
+        # make datasets and splits
+        dataset = tf.data.TFRecordDataset(self.params["record_path"])
+        dataset = dataset.map(
+            lambda x: tf.io.parse_single_example(x, feature_description),
+            num_parallel_calls=tf.data.AUTOTUNE
+        )
+        dataset = dataset.map(parse_dict, num_parallel_calls=tf.data.AUTOTUNE)
+
+        # split into train and validation
+        self.validation_dataset = dataset.take(self.params["num_validation"])
+        self.train_dataset = dataset.skip(self.params["num_validation"])
+
+    def prep_model(self):
+        """Prepares the model for training"""
+        # prepare folders
+        self.params["model_dir"] = os.path.join(
+            os.path.normpath(self.params["path"]), self.params["experiment"]
+        )
+        self.params["log_dir"] = os.path.join(self.params["model_dir"], "logs", str(int(time())))
+        os.makedirs(self.params["model_dir"], exist_ok=True)
+        os.makedirs(self.params["log_dir"], exist_ok=True)
+        if "model_path" not in self.params.keys() or self.params["model_path"] is None:
+            self.params["model_path"] = os.path.join(
+                self.params["model_dir"], "{}.h5".format(self.params["experiment"])
+            )
+        self.params["loss_path"] = os.path.join(
+            self.params["model_dir"], "{}.npz".format(self.params["experiment"])
+        )
+
+        # initialize optimizer and lr scheduler
+        # replace with AdamW when available
+        self.lr_sched = CosineDecay(
+            initial_learning_rate=self.params["lr"],
+            decay_steps=self.params["num_steps"],
+            alpha=1e-6,
+        )
+        self.optimizer = Adam(learning_rate=self.lr_sched, clipnorm=0.001)
+
+        # initialize model
+        if "test" in self.params.keys() and self.params["test"]:
+            self.model = tf.keras.Sequential(
+                [tf.keras.layers.Conv2D(
+                        1, (3, 3), input_shape=self.params["input_shape"], padding="same",
+                        name="semantic_head", activation="sigmoid", data_format="channels_last",
+                    )]
+            )
+        else:
+            self.model = PanopticNet(
+                backbone=self.params["backbone"], input_shape=self.params["input_shape"],
+                norm_method="std", num_semantic_classes=self.params["classes"],
+                create_semantic_head=create_semantic_head,
+            )
+
+        loss = {}
+        # Give losses for all of the semantic heads
+        for layer in self.model.layers:
+            if layer.name.startswith("semantic_"):
+                loss[layer.name] = self.prep_loss()
+
+        if "weight_decay" in self.params.keys():
+            self.add_weight_decay()
+        self.model.compile(loss=loss, optimizer=self.optimizer)
+
+
+    @staticmethod
+    def train_step(model, optimizer, loss_fn, aug_fn, loss_mask, x, y_gt):
+        """Performs a training step
+        Args:
+            model (tf.keras.Model): model to train
+            optimizer (tf.keras.optimizers.Optimizer): optimizer to use
+            loss_fn (tf.keras.losses.Loss): loss function to use
+            loss_mask (tf.Tensor): mask to apply to loss
+            x (tf.Tensor): input data
+            y_gt (tf.Tensor): ground truth labels
+        Returns:
+            tf.Tensor: loss value
+        """
+        x_aug, loss_mask_aug, y_gt_aug = aug_fn(x, loss_mask, y_gt)
+        with tf.GradientTape() as tape:
+            y_pred = model(x, training=True)
+            loss_img = loss_fn(y_gt, y_pred)
+            loss_img *= loss_mask
+            loss = tf.reduce_mean(loss_img)
+        gradients = tape.gradient(loss, model.trainable_variables)
+        optimizer.apply_gradients(zip(gradients, model.trainable_variables))
+        return loss
+
+    def train(self):
+        """Calls prep functions and starts training loops"""
+        self.prep_data()
+        self.prep_model()
+        self.confidence_loss_thresholds = self.matched_high_confidence_selection_thresholds()
+        #
+        validation_dataset = self.validation_dataset.map(
+                self.prep_batches, num_parallel_calls=tf.data.AUTOTUNE
+        )
+        # shuffle, batch and augment the training data
+        self.train_dataset = self.train_dataset.shuffle(self.params["shuffle_buffer_size"]).batch(
+            self.params["batch_size"]
+        )
+        self.train_dataset = self.train_dataset.prefetch(tf.data.AUTOTUNE)
+
+        with open(os.path.join(self.params['model_dir'], "params.toml"), "w") as f:
+            toml.dump(self.params, f)
+        # train the model
+        for batch in self.train_dataset:
+            inputs, targets = self.prep_batches(batch)
+            y_pred = self.model(inputs, training=False)
+            loss_img = self.loss_fn(targets, y_pred)
+            # map over batch dimension
+            uniques, loss_per_cell = tf.map_fn(
+                self.reduce_to_cells, (loss_img, batch["instance_mask"]), infer_shape=False,
+                fn_output_signature=[
+                    tf.RaggedTensorSpec(shape=[None], dtype=tf.int32, ragged_rank=0),
+                    tf.RaggedTensorSpec(shape=[None], dtype=tf.float32, ragged_rank=0)
+                ]
+            )
+            batch["activity_df"] =  [pd.read_json(df.decode()) for df in batch["activity_df"].numpy()]
+            batch["activity_df"] = [df.merge(pd.DataFrame({
+                "labels": uniques[i].numpy(), "loss": loss_per_cell[i].numpy()}), on="labels")
+                for i, df in enumerate(batch["activity_df"])]
+            #
+            loss_mask = self.batchwise_loss_selection(
+                batch["activity_df"], batch["instance_mask"], batch["marker"]
+            )
+            loss_mask = tf.cast(loss_mask, tf.float32)
+            aug_fn = lambda x, y, z: (x, y, z)
+            loss = self.train_step(
+                self.model, self.optimizer, self.loss_fn, aug_fn, loss_mask, inputs,
+                targets
+            )
+            print(loss)
+
+    @staticmethod
+    @tf.autograph.experimental.do_not_convert
+    def reduce_to_cells(tuple_in):
+        """Reduces the prediction to the cell level
+        Args:
+            tuple_in (tf.Tensor): tuple of (loss_img, instance_mask)
+        Returns:
+            tuple: tuple of (uniques, mean_per_cell)
+                uniques (tf.Tensor): unique cell ids, batch x num_cells 0-padded to 200
+                mean_per_cell (tf.Tensor): mean loss per cell, batch x num_cells 0-padded to 200
+        """
+        pred, instance_mask = tuple_in
+        instance_mask_flat = tf.cast(tf.reshape(instance_mask, -1), tf.int32) # b x (h*w)
+        pred_flat = tf.cast(tf.reshape(pred, -1), tf.float32)
+        uniques, _ = tf.unique(instance_mask_flat)
+        sort_order = tf.argsort(instance_mask_flat)
+        instance_mask_flat = tf.gather(instance_mask_flat, sort_order)
+        pred_flat = tf.gather(pred_flat, sort_order)
+        mean_per_cell = tf.math.segment_mean(pred_flat, instance_mask_flat)
+        mean_per_cell = tf.gather(mean_per_cell, uniques)
+        return [uniques, mean_per_cell]
+
+    def batchwise_loss_selection(self, activity_df, instance_mask, marker):
+        """Selects the cells with the lowest loss for each class and runs 
+            matched_high_confidence_selection internally
+        Args:
+            activity_df (pd.DataFrame): dataframe with columns "labels", "activity" and "loss"
+            instance_mask (tf.Tensor): instance_masks
+        Returns:
+            tf.Tensor: loss_mask
+        """
+        loss_selection = []
+        for df, mask, mark in zip(activity_df, instance_mask, marker):
+            if df.shape[0] == 0:
+                loss_selection.append(tf.squeeze(tf.zeros_like(mask, tf.float32)))
+                continue
+            mark = mark.numpy().decode()
+
+            positive_df = df[df["activity"] == 1]
+            negative_df = df[df["activity"] == 0]
+            selected_subset = []
+            # matched high confidence selection
+            selected_subset += self.class_wise_loss_selection(positive_df, negative_df, mark)
+            selected_subset += self.matched_high_confidence_selection(positive_df, negative_df)
+            selected_subset = pd.concat(selected_subset)
+            positive_mask = tf.reduce_any(
+                tf.equal(mask, np.unique(selected_subset.labels.values)), axis=-1
+            )
+            loss_selection.append(tf.cast(positive_mask, tf.float32))
+        return tf.stack(loss_selection)
+
+    def class_wise_loss_selection(self, positive_df, negative_df, mark):
+        """Selects the cells with the lowest loss for each class and runs
+        Args:
+            positive_df (pd.DataFrame): dataframe with columns "labels", "activity" and "loss"
+            negative_df (pd.DataFrame): dataframe with columns "labels", "activity" and "loss"
+            mark (str): marker name
+        Returns:
+            list: list of pd.DataFrame that contain the selected cells
+        """
+        ema = self.params["ema"]
+        selected_subset = []
+        # get the quantile for gt=0 / gt=1 separately and store cell labels in selected_subset
+        if mark not in self.class_wise_loss_quantiles.keys():
+            # add keys to dict if not present and set ema to 1 for initialization
+            self.class_wise_loss_quantiles[mark] = {"positive": 1.0, "negative": 1.0}
+            ema = 1.0
+        if positive_df.shape[0] >0:
+            self.class_wise_loss_quantiles[mark]["positive"] = \
+                self.class_wise_loss_quantiles[mark]["positive"] * \
+                (1 - ema) + np.quantile(positive_df.loss, self.quantile) * ema
+            selected_subset.append(
+                positive_df[positive_df["loss"] <= self.class_wise_loss_quantiles[mark]["positive"]])
+        if negative_df.shape[0] >0:
+            self.class_wise_loss_quantiles[mark]["negative"] = \
+                self.class_wise_loss_quantiles[mark]["negative"] * \
+                (1 - ema) + np.quantile(negative_df.loss, self.quantile) * ema
+            selected_subset.append(
+                negative_df[negative_df["loss"] <= self.class_wise_loss_quantiles[mark]["negative"]])
+        return selected_subset
+
+    def matched_high_confidence_selection(self, positive_df, negative_df):
+        """Selects the cells with the highest confidence for each class (negative/positive)
+        Args:
+            positive_df (pd.DataFrame): dataframe with columns "labels", "activity" and "loss"
+                containing only GT positive cells
+            negative_df (pd.DataFrame): dataframe with columns "labels", "activity" and "loss"
+                containing only GT negative cells            
+        Returns:
+            list: list of pd.DataFrame that contains the selected cells
+        """
+        selected_subset = []
+        if positive_df.shape[0] > 0:
+            selected_subset.append(positive_df[positive_df.loss<self.confidence_loss_thresholds["positive"]])
+        if negative_df.shape[0] > 0:
+            selected_subset.append(negative_df[negative_df.loss<self.confidence_loss_thresholds["negative"]])
+        return selected_subset

--- a/cell_classification/promix_naive_test.py
+++ b/cell_classification/promix_naive_test.py
@@ -1,0 +1,67 @@
+from segmentation_data_prep_test import prep_object_and_inputs
+from promix_naive import PromixNaive
+import toml
+import tempfile
+import numpy as np
+import tensorflow as tf
+
+
+def test_train():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        data_prep, _, _, _ = prep_object_and_inputs(temp_dir)
+        data_prep.tf_record_path = temp_dir
+        data_prep.make_tf_record()
+        tf_record_path = os.path.join(data_prep.tf_record_path, data_prep.dataset + ".tfrecord")
+        params = toml.load("cell_classification/configs/params.toml")
+        params["record_path"] = tf_record_path
+        params["path"] = temp_dir
+        params["experiment"] = "test"
+        params["num_epochs"] = 2
+        params["num_validation"] = 2
+        params["batch_size"] = 2
+        params["test"] = True
+        params["weight_decay"] = 1e-4
+        params["steps_per_epoch"] = 5000
+        trainer = PromixNaive(params)
+        trainer.train()
+
+
+def test_reduce_to_cells():
+    params = toml.load("cell_classification/configs/params.toml")
+    params["test"] = True
+    params["quantile"] = 0.3
+    pred = np.random.rand(16,256,266)
+    instance_mask = np.random.randint(0, 100, (16,256,266))
+    instance_mask[-1, instance_mask[-1]==1] = 0
+    marker_activity_mask = np.zeros_like(instance_mask)
+    marker_activity_mask[instance_mask > 90] = 1
+    trainer = PromixNaive(params)
+    uniques, mean_per_cell = tf.map_fn(trainer.reduce_to_cells, (pred, instance_mask),
+        infer_shape=False, fn_output_signature=(
+            tf.RaggedTensorSpec(shape=[None], dtype=tf.int32, ragged_rank=0), tf.RaggedTensorSpec(shape=[None], dtype=tf.float32, ragged_rank=0)
+        )
+    )
+
+    # check that the output has the right dimension
+    assert uniques.shape[0] == instance_mask.shape[0]
+    assert mean_per_cell.shape[0] == instance_mask.shape[0]
+
+    # check that the output is correct
+    assert set(np.unique(instance_mask[0])) == set(uniques[0].numpy())
+    for i in np.unique(instance_mask[0]):
+        assert np.isclose(
+            np.mean(pred[0][instance_mask[0]==i]), mean_per_cell[0][uniques[0]==i].numpy().max()
+        )
+
+
+def test_train():
+    params = toml.load("cell_classification/configs/params.toml")
+    params["test"] = True
+    params["quantile"] = 0.3
+    params["ema"] = 0.01
+    params["confidence_thresholds"] = [0.1, 0.9]
+    params["num_steps"] = 40
+    trainer = PromixNaive(params)
+    trainer.train()
+
+test_train()

--- a/cell_classification/promix_naive_test.py
+++ b/cell_classification/promix_naive_test.py
@@ -4,6 +4,51 @@ import toml
 import tempfile
 import numpy as np
 import tensorflow as tf
+import os
+
+
+def test_reduce_to_cells():
+    params = toml.load("cell_classification/configs/params.toml")
+    params["test"] = True
+    pred = np.random.rand(16, 256, 266)
+    instance_mask = np.random.randint(0, 100, (16, 256, 266))
+    instance_mask[-1, instance_mask[-1] == 1] = 0
+    marker_activity_mask = np.zeros_like(instance_mask)
+    marker_activity_mask[instance_mask > 90] = 1
+    trainer = PromixNaive(params)
+    uniques, mean_per_cell = tf.map_fn(
+        trainer.reduce_to_cells,
+        (pred, instance_mask),
+        infer_shape=False,
+        fn_output_signature=[
+            tf.RaggedTensorSpec(shape=[None], dtype=tf.int32, ragged_rank=0),
+            tf.RaggedTensorSpec(shape=[None], dtype=tf.float32, ragged_rank=0),
+        ],
+    )
+
+    # check that the output has the right dimension
+    assert uniques.shape[0] == instance_mask.shape[0]
+    assert mean_per_cell.shape[0] == instance_mask.shape[0]
+
+    # check that the output is correct
+    assert set(np.unique(instance_mask[0])) == set(uniques[0].numpy())
+    for i in np.unique(instance_mask[0]):
+        assert np.isclose(
+            np.mean(pred[0][instance_mask[0] == i]),
+            mean_per_cell[0][uniques[0] == i].numpy().max(),
+        )
+
+
+def test_matched_high_confidence_selection_thresholds():
+    params = toml.load("cell_classification/configs/params.toml")
+    params["test"] = True
+    trainer = PromixNaive(params)
+    thresholds = trainer.matched_high_confidence_selection_thresholds()
+
+    # check that the output has the right dimension
+    assert len(thresholds) == 2
+    assert thresholds["positive"] > 0.0
+    assert thresholds["negative"] > 0.0
 
 
 def test_train():
@@ -16,52 +61,59 @@ def test_train():
         params["record_path"] = tf_record_path
         params["path"] = temp_dir
         params["experiment"] = "test"
-        params["num_epochs"] = 2
+        params["num_steps"] = 7
         params["num_validation"] = 2
         params["batch_size"] = 2
         params["test"] = True
         params["weight_decay"] = 1e-4
-        params["steps_per_epoch"] = 5000
+        params["snap_steps"] = 5
+        params["val_steps"] = 5
+        params["quantile"] = 0.3
+        params["ema"] = 0.01
+        params["confidence_thresholds"] = [0.1, 0.9]
         trainer = PromixNaive(params)
         trainer.train()
 
+        # check params.toml is dumped to file and contains the created paths
+        assert "params.toml" in os.listdir(trainer.params["model_dir"])
+        loaded_params = toml.load(os.path.join(trainer.params["model_dir"], "params.toml"))
+        for key in ["model_dir", "log_dir", "model_path"]:
+            assert key in list(loaded_params.keys())
 
-def test_reduce_to_cells():
-    params = toml.load("cell_classification/configs/params.toml")
-    params["test"] = True
-    params["quantile"] = 0.3
-    pred = np.random.rand(16,256,266)
-    instance_mask = np.random.randint(0, 100, (16,256,266))
-    instance_mask[-1, instance_mask[-1]==1] = 0
-    marker_activity_mask = np.zeros_like(instance_mask)
-    marker_activity_mask[instance_mask > 90] = 1
-    trainer = PromixNaive(params)
-    uniques, mean_per_cell = tf.map_fn(trainer.reduce_to_cells, (pred, instance_mask),
-        infer_shape=False, fn_output_signature=(
-            tf.RaggedTensorSpec(shape=[None], dtype=tf.int32, ragged_rank=0), tf.RaggedTensorSpec(shape=[None], dtype=tf.float32, ragged_rank=0)
-        )
-    )
-
-    # check that the output has the right dimension
-    assert uniques.shape[0] == instance_mask.shape[0]
-    assert mean_per_cell.shape[0] == instance_mask.shape[0]
-
-    # check that the output is correct
-    assert set(np.unique(instance_mask[0])) == set(uniques[0].numpy())
-    for i in np.unique(instance_mask[0]):
-        assert np.isclose(
-            np.mean(pred[0][instance_mask[0]==i]), mean_per_cell[0][uniques[0]==i].numpy().max()
-        )
+        # check if model can be loaded from file
+        trainer.model = None
+        trainer.load_model(trainer.params["model_path"])
+        assert isinstance(trainer.model, tf.keras.Model)
 
 
-def test_train():
-    params = toml.load("cell_classification/configs/params.toml")
-    params["test"] = True
-    params["quantile"] = 0.3
-    params["ema"] = 0.01
-    params["confidence_thresholds"] = [0.1, 0.9]
-    params["num_steps"] = 40
-    trainer = PromixNaive(params)
-    trainer.train()
+def test_prep_data():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        data_prep, _, _, _ = prep_object_and_inputs(temp_dir)
+        data_prep.tf_record_path = temp_dir
+        data_prep.make_tf_record()
+        tf_record_path = os.path.join(data_prep.tf_record_path, data_prep.dataset + ".tfrecord")
+        params = toml.load("cell_classification/configs/params.toml")
+        params["record_path"] = tf_record_path
+        params["path"] = temp_dir
+        params["experiment"] = "test"
+        params["num_steps"] = 3
+        params["num_validation"] = 2
+        params["batch_size"] = 2
+        trainer = PromixNaive(params)
+        trainer.prep_data()
 
-test_train()
+        # check if train and validation datasets exists and are of the right type
+        assert isinstance(trainer.validation_dataset, tf.data.Dataset)
+        assert isinstance(trainer.train_dataset, tf.data.Dataset)
+
+
+def test_class_wise_loss_selection():
+    pass
+
+
+def test_matched_high_confidence_selection():
+    pass
+
+
+def test_batchwise_loss_selection():
+    pass


### PR DESCRIPTION
**What is the purpose of this PR?**

This PR adds promix naive as described in #26, but without data augmentation. I'd add a new data augmentation pipeline in a separate PR, since this one has already lots of changes.

**How did you implement your changes**

As described in the design doc #26 I sub-classes ModelBuilder, replaced class functions `prep_data`, `prep_model `, `train`, `train_step` and added the following class functions:
- `matched_high_confidence_selection_thresholds`, that converts confidence thresholds to loss thresholds
- `reduce_to_cells` that calculates mean-per-cell predictions from semantic segmentation maps
- `batchwise_loss_selection` which iterates over the batch and calculates the `loss_mask` for each sample
- `class_wise_loss_selection` which implements the class-wise loss selection procedure from promix
- `matched_high_confidence_selection` which implements the matched high-confidence selection from promix. Here we do it based on the loss instead of the confidence for shorter runtime.

In class `ModelBuilder` I disentangled `tensorboard_callbacks` from the training loop into its own class function to re-use it in `PromixNaive`.

**Remaining issues**

Need to add data augmentation and MixUp as stated in issue #26 