### PR TITLE
Added exclude_background_tiles and fixed normalization

### DIFF
--- a/cell_classification/prepare_data_script.py
+++ b/cell_classification/prepare_data_script.py
@@ -23,7 +23,7 @@ data_prep = SegmentationTFRecords(
     stride=[240, 240],
     tf_record_path=os.path.normpath("C:/Users/lorenz/Desktop/angelo_lab/TONIC"),
     normalization_dict_path=os.path.normpath(
-        "C:/Users/lorenz/Desktop/angelo_lab/TONIC/normalization_dict.json"
+       "C:/Users/lorenz/Desktop/angelo_lab/TONIC/normalization_dict.json"
     ),
     normalization_quantile=0.99,
     cell_type_key="cell_meta_cluster",
@@ -31,6 +31,7 @@ data_prep = SegmentationTFRecords(
     segmentation_fname="cell_segmentation",
     segmentation_naming_convention=naming_convention,
     segment_label_key="label",
+    exlude_background_tiles=True,
 )
 
 data_prep.make_tf_record()


### PR DESCRIPTION
**What is the purpose of this PR?**

This PR changes the `SegmentationTFRecords` class:
1. quantile normalization now only calculates quantiles on pixels whose intensity is > 0, so that sparse markers don't get super dim because of normalization
2. we add an argument `exlude_background_tiles`  to the class, if it's set to true, only tiles that contain foreground in the label mask (i.e. 1s or 2s) are stored in the tfrecord. All tiles that only contain background (0s) are not saved in the tfrecord.

**How did you implement your changes**

Changed a few lines in `segmentation_data_prep.py`

**Remaining issues**

None
