### PR TITLE
Filter out sparse examples from the training data

### DIFF
--- a/cell_classification/model_builder_test.py
+++ b/cell_classification/model_builder_test.py
@@ -7,8 +7,8 @@ import os
 import toml
 from model_builder import ModelBuilder
 import h5py
-from copy import deepcopy
 import pandas as pd
+import json
 
 tf.config.run_functions_eagerly(True)
 
@@ -336,3 +336,11 @@ def test_quantile_filter():
             num_cells for num_cells in unfiltered_num_cells if num_cells not in filtered_num_cells
         ]
         assert np.max(diff) < np.min(filtered_num_cells)
+
+        # check if dataset_num_pos_dict.json was saved and contains the right values
+        assert os.path.exists(trainer.num_pos_dict_path)
+
+        with open(trainer.num_pos_dict_path, "r") as f:
+            num_pos_dict = json.load(f)
+
+        assert np.array_equal(sorted(num_pos_dict["CD4"]), sorted(unfiltered_num_cells))

--- a/cell_classification/prepare_data_script.py
+++ b/cell_classification/prepare_data_script.py
@@ -5,25 +5,29 @@ os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 
 def naming_convention(fname):
     return os.path.join(
-        "C:/TONIC_Cohort/segmentation_data/deepcell_output", fname + "_feature_0.tif"
+        "C:/Users/lorenz/Desktop/angelo_lab/data/TONIC/raw/segmentation_data/deepcell_output",
+        fname + "_feature_0.tif"
     )
 
 
 data_prep = SegmentationTFRecords(
-    data_dir=os.path.normpath("C:/TONIC_Cohort/image_data/samples"),
+    data_dir=os.path.normpath(
+        "C:/Users/lorenz/Desktop/angelo_lab/data/TONIC/raw/image_data/samples"
+    ),
     cell_table_path=os.path.normpath(
-        "C:/TONIC_Cohort/combined_cell_table_normalized_cell_labels_updated.csv"
+        "C:/Users/lorenz/Desktop/angelo_lab/data/TONIC/raw/" +
+        "combined_cell_table_normalized_cell_labels_updated.csv"
     ),
     conversion_matrix_path=os.path.normpath(
-        "C:/TONIC_Cohort/TONIC_conversion_matrix.csv"
+        "C:/Users/lorenz/Desktop/angelo_lab/data/TONIC/raw/TONIC_conversion_matrix.csv"
     ),
     imaging_platform="MIBI",
     dataset="TONIC",
     tile_size=[256, 256],
     stride=[240, 240],
-    tf_record_path=os.path.normpath("C:/Users/lorenz/Desktop/angelo_lab/TONIC"),
+    tf_record_path=os.path.normpath("C:/Users/lorenz/Desktop/angelo_lab/data/TONIC"),
     normalization_dict_path=os.path.normpath(
-       "C:/Users/lorenz/Desktop/angelo_lab/TONIC/normalization_dict.json"
+      "C:/Users/lorenz/Desktop/angelo_lab/TONIC/normalization_dict.json"
     ),
     normalization_quantile=0.999,
     cell_type_key="cell_meta_cluster",
@@ -31,7 +35,7 @@ data_prep = SegmentationTFRecords(
     segmentation_fname="cell_segmentation",
     segmentation_naming_convention=naming_convention,
     segment_label_key="label",
-    exlude_background_tiles=True,
+    exclude_background_tiles=True,
 )
 
 data_prep.make_tf_record()

--- a/cell_classification/promix_naive.py
+++ b/cell_classification/promix_naive.py
@@ -77,6 +77,10 @@ class PromixNaive(ModelBuilder):
         )
         dataset = dataset.map(parse_dict, num_parallel_calls=tf.data.AUTOTUNE)
 
+        # filter out sparse samples
+        if "filter_quantile" in self.params.keys():
+            dataset = self.quantile_filter(dataset)
+
         # split into train and validation
         self.validation_dataset = dataset.take(self.params["num_validation"])
         self.train_dataset = dataset.skip(self.params["num_validation"])

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -515,6 +515,7 @@ def parse_dict(deserialized_dict):
         example[key] = tf.strings.unicode_encode(
             tf.cast(deserialized_dict[key], tf.int32), "UTF-8"
         )
+        example[key] = example[key]
         if hasattr(example[key], "numpy"):
             example[key] = example[key].numpy().decode()
     for key in ["binary_mask", "marker_activity_mask"]:

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -515,7 +515,6 @@ def parse_dict(deserialized_dict):
         example[key] = tf.strings.unicode_encode(
             tf.cast(deserialized_dict[key], tf.int32), "UTF-8"
         )
-        example[key] = example[key]
         if hasattr(example[key], "numpy"):
             example[key] = example[key].numpy().decode()
     for key in ["binary_mask", "marker_activity_mask"]:

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -80,6 +80,7 @@ def test_get_image():
 
 def prepare_test_data_folders(num_folders, temp_dir, selected_markers, random=False, scale=[1.0]):
     data_folders = []
+    np.random.seed(42)
     if len(scale) != num_folders:
         scale = [1.0] * num_folders
     for i in range(num_folders):


### PR DESCRIPTION
**What is the purpose of this PR?**

This PR closes #34 by adding function `quantile_filter` to `ModelBuilder`.

**How did you implement your changes**
Added function `quantile_filter` to the `ModelBuilder` class that first calculates the x-quantile of positive cells per tile for each marker and then filters out the tiles whose number of positive cells is below the quantile. Also I aligned `prep_data` in `ModelBuilder` with the one that was in `PromixNaive` before. Thus we can get rid of the one in `PromixNaive` because it gets inherited from `ModelBuilder`.

**Remaining issues**

None