### PR TITLE
Added SimpleTFRecords class for handling MSK data

### DIFF
--- a/cell_classification/prepare_data_script_MSK_colon.py
+++ b/cell_classification/prepare_data_script_MSK_colon.py
@@ -1,0 +1,37 @@
+import os
+from simple_data_prep import SimpleTFRecords
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+
+def naming_convention(fname):
+    return os.path.join(
+        "C:/Users/lorenz/Desktop/angelo_lab/data/MSKCC_colon/segmentation",
+        fname + "feature_0.ome.tif"
+    )
+
+
+data_prep = SimpleTFRecords(
+    data_dir=os.path.normpath(
+        "C:/Users/lorenz/Desktop/angelo_lab/data/MSKCC_colon/raw_structured"
+    ),
+    cell_table_path=os.path.normpath(
+        "C:/Users/lorenz/Desktop/angelo_lab/data/MSKCC_colon/cell_table.csv"
+    ),
+    imaging_platform="Vectra",
+    dataset="MSK_colon",
+    tile_size=[256, 256],
+    stride=[240, 240],
+    tf_record_path=os.path.normpath("C:/Users/lorenz/Desktop/angelo_lab/data/MSKCC_colon"),
+    normalization_quantile=0.999,
+    selected_markers=["CD3", "CD8", "Foxp3", "ICOS", "panCK+CK7+CAM5.2", "PD-L1"],
+    sample_key="fov",
+    segment_label_key="labels",
+    segmentation_naming_convention=naming_convention,
+    exclude_background_tiles=True,
+    img_suffix=".ome.tif",
+    normalization_dict_path=os.path.normpath(
+        "C:/Users/lorenz/Desktop/angelo_lab/data/MSKCC_colon/normalization_dict.json"
+    ),
+)
+
+data_prep.make_tf_record()

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -296,7 +296,7 @@ class SegmentationTFRecords:
 
     def load_and_check_input(self):
         """Checks the input for correctness"""
-
+        self.cell_type_table = pd.read_csv(self.cell_table_path)
         self.check_additional_inputs()
         # make tfrecord path
         os.makedirs(self.tf_record_path, exist_ok=True)
@@ -344,16 +344,6 @@ class SegmentationTFRecords:
             raise ValueError("The normalization_quantile is not in [0, 1]")
 
         # CELL TYPE TABLE
-        # load cell_types.csv
-        self.cell_type_table = pd.read_csv(self.cell_table_path)
-        self.cell_type_table.drop(self.cell_type_table.columns.difference([
-            self.cell_type_key, self.segment_label_key, self.sample_key,
-        ]), 1, inplace=True)
-
-        # check if cell_type_key is in cell_type_table
-        if self.cell_type_key not in self.cell_type_table.columns:
-            raise ValueError("The cell_type_key is not in the cell_type_table")
-
         # check if segment_label_key is in cell_type_table
         if self.segment_label_key not in self.cell_type_table.columns:
             raise ValueError("The segment_label_key is not in the cell_type_table")
@@ -379,6 +369,16 @@ class SegmentationTFRecords:
         # check if markers were selected or take all markers from conversion matrix
         if self.selected_markers is None:
             self.selected_markers = list(self.conversion_matrix.columns)
+
+        # CELL TYPE TABLE
+        # drop all columns except cell_type_key, segment_label_key, sample_key
+        self.cell_type_table.drop(self.cell_type_table.columns.difference([
+            self.cell_type_key, self.segment_label_key, self.sample_key,
+        ]), 1, inplace=True)
+
+        # check if cell_type_key is in cell_type_table
+        if self.cell_type_key not in self.cell_type_table.columns:
+            raise ValueError("The cell_type_key is not in the cell_type_table")
 
         # check if selected markers are in conversion matrix
         verify_in_list(

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -143,7 +143,7 @@ class SegmentationTFRecords:
             )
         return interior, instance_mask
 
-    def get_marker_activity(self, sample_name, conversion_matrix, marker):
+    def get_marker_activity(self, sample_name, marker):
         """Gets the marker activity for the given labels
         Args:
             sample_name (str):
@@ -162,7 +162,7 @@ class SegmentationTFRecords:
         df = pd.DataFrame(
             {
                 "labels": self.sample_subset[self.segment_label_key],
-                "activity": conversion_matrix.loc[cell_types, marker].values,
+                "activity": self.conversion_matrix.loc[cell_types, marker].values,
                 "cell_type": cell_types,
             }
         )
@@ -212,7 +212,7 @@ class SegmentationTFRecords:
         mplex_img = mplex_img.clip(0, 1)
         fov = os.path.basename(data_folder)
         # get the cell types and marker activity mask
-        marker_activity, cell_types = self.get_marker_activity(fov, self.conversion_matrix, marker)
+        marker_activity, cell_types = self.get_marker_activity(fov, marker)
         marker_activity_mask = self.get_marker_activity_mask(
             self.instance_mask, self.binary_mask, marker_activity
         )
@@ -296,6 +296,8 @@ class SegmentationTFRecords:
 
     def load_and_check_input(self):
         """Checks the input for correctness"""
+
+        self.check_additional_inputs()
         # make tfrecord path
         os.makedirs(self.tf_record_path, exist_ok=True)
 
@@ -305,24 +307,9 @@ class SegmentationTFRecords:
             os.path.join(self.data_dir, folder) for folder in list_folders(self.data_dir)
         ]
 
-        # CONVERSION MATRIX
-        # read the file
-        validate_paths(self.conversion_matrix_path, data_prefix=False)
-        self.conversion_matrix = pd.read_csv(self.conversion_matrix_path, index_col=0)
-
-        # check if markers were selected or take all markers from conversion matrix
-        if self.selected_markers is None:
-            self.selected_markers = list(self.conversion_matrix.columns)
-
         # check if selected markers are a list
         if not isinstance(self.selected_markers, list):
             self.selected_markers = [self.selected_markers]
-
-        # check if selected markers are in conversion matrix
-        verify_in_list(
-            selected_markers=self.selected_markers,
-            conversion_matrix_columns=self.conversion_matrix.columns,
-        )
 
         # check if selected markers are in data folders
         for marker in self.selected_markers:
@@ -380,6 +367,23 @@ class SegmentationTFRecords:
             sample_names=self.cell_type_table[self.sample_key].values,
             data_folders=list_folders(self.data_dir),
             warn=True
+        )
+
+    def check_additional_inputs(self):
+        """Checks the additional inputs for correctness"""
+        # CONVERSION MATRIX
+        # read the file
+        validate_paths(self.conversion_matrix_path, data_prefix=False)
+        self.conversion_matrix = pd.read_csv(self.conversion_matrix_path, index_col=0)
+
+        # check if markers were selected or take all markers from conversion matrix
+        if self.selected_markers is None:
+            self.selected_markers = list(self.conversion_matrix.columns)
+
+        # check if selected markers are in conversion matrix
+        verify_in_list(
+            selected_markers=self.selected_markers,
+            conversion_matrix_columns=self.conversion_matrix.columns,
         )
 
         # make cell_types lowercase to make matching easier

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -217,7 +217,7 @@ def test_load_and_check_input():
             index=["stromal", "FAP", "NK", "CD4", "CD14", "CD163"],
         )
         conversion_matrix_path = os.path.join(temp_dir, "conversion_matrix.csv")
-        conversion_matrix.to_csv(conversion_matrix_path, index=False)
+        conversion_matrix.to_csv(conversion_matrix_path, index=True)
         data_prep = copy.deepcopy(data_prep_working)
         data_prep.conversion_matrix_path = conversion_matrix_path
         data_prep.normalization_dict_path = os.path.join(temp_dir, "norm_dict.json")
@@ -233,7 +233,7 @@ def test_load_and_check_input():
             index=["stromal", "FAP", "NK", "CD4", "CD14", "CD163"],
         )
         conversion_matrix_path = os.path.join(temp_dir, "conversion_matrix.csv")
-        conversion_matrix.to_csv(conversion_matrix_path, index=False)
+        conversion_matrix.to_csv(conversion_matrix_path, index=True)
         data_prep = copy.deepcopy(data_prep_working)
         data_prep.selected_markers = ["ZYX"]
         data_prep.conversion_matrix_path = conversion_matrix_path
@@ -344,8 +344,9 @@ def test_get_marker_activity():
     fov_1_subset = cell_table[cell_table.SampleID == sample_name]
     data_prep.sample_subset = fov_1_subset
     conversion_matrix.index = conversion_matrix.index.str.lower()
+    data_prep.conversion_matrix = conversion_matrix
     fov_1_subset["cluster_labels"] = fov_1_subset["cluster_labels"].str.lower()
-    marker_activity, _ = data_prep.get_marker_activity(sample_name, conversion_matrix, marker)
+    marker_activity, _ = data_prep.get_marker_activity(sample_name, marker)
     # check if the we get marker_acitivity for all labels in the fov_1 subset
     assert np.array_equal(marker_activity.labels, fov_1_subset.labels)
 

--- a/cell_classification/simple_data_prep.py
+++ b/cell_classification/simple_data_prep.py
@@ -53,7 +53,15 @@ class SimpleTFRecords(SegmentationTFRecords):
             gt_suffix (str):
                 The suffix of the ground truth column in the cell_table
         """
-        super().__init__()
+        super().__init__(
+            data_dir=data_dir, cell_table_path=cell_table_path, imaging_platform=imaging_platform,
+            dataset=dataset, tile_size=tile_size, stride=stride, tf_record_path=tf_record_path,
+            selected_markers=selected_markers, normalization_dict_path=normalization_dict_path,
+            normalization_quantile=normalization_quantile, segmentation_fname=segmentation_fname,
+            segmentation_naming_convention=segmentation_naming_convention, resize=resize,
+            exclude_background_tiles=exclude_background_tiles, img_suffix=img_suffix,
+            sample_key=sample_key, segment_label_key=segment_label_key, conversion_matrix_path=None
+        )
         self.selected_markers = selected_markers
         self.data_dir = data_dir
         self.normalization_dict_path = normalization_dict_path
@@ -87,16 +95,14 @@ class SimpleTFRecords(SegmentationTFRecords):
                 The marker activity for the given labels, 1 if the marker is active, 0
                 otherwise and -1 if the marker is not specific enough to be considered active
         """
-        cell_types = self.sample_subset[self.cell_type_key].str.lower().values
 
         df = pd.DataFrame(
             {
                 "labels": self.sample_subset[self.segment_label_key],
-                "activity": self.sample_subset[self.gt_key],
-                "cell_type": cell_types,
+                "activity": self.sample_subset[marker + self.gt_suffix],
             }
         )
-        return df, cell_types
+        return df, None
 
     def check_additional_inputs(self):
         """Checks additional inputs for correctness"""

--- a/cell_classification/simple_data_prep.py
+++ b/cell_classification/simple_data_prep.py
@@ -1,0 +1,103 @@
+import pandas as pd
+from segmentation_data_prep import SegmentationTFRecords
+
+
+class SimpleTFRecords(SegmentationTFRecords):
+    """Prepares the data for the segmentation model"""
+    def __init__(
+        self, data_dir, cell_table_path, imaging_platform, dataset, tile_size, stride,
+        tf_record_path, selected_markers=None, normalization_dict_path=None,
+        normalization_quantile=0.999, segmentation_naming_convention=None,
+        segmentation_fname="cell_segmentation",  exclude_background_tiles=False, resize=None,
+        img_suffix=".tiff", sample_key="SampleID", segment_label_key="labels", gt_suffix="_gt",
+
+    ):
+        """Initializes SegmentationTFRecords and loads everything except the images
+
+        Args:
+            data_dir str:
+                Path where the data is stored
+            cell_table_path (str):
+                Path to the cell table
+            imaging_platform (str):
+                The imaging platform used to generate the multiplexed imaging data
+            dataset (str):
+                The dataset where the imaging data comes from
+            tile_size list [int,int]:
+                The size of the tiles to use for the segmentation model
+            stride list [int,int]:
+                The stride to tile the data
+            tf_record_path (str):
+                The path to the tf record to make
+            selected_markers (list):
+                The markers of interest for generating the tf record. If None, all markers
+                mentioned in the conversion_matrix are used
+            normalization_dict_path (str):
+                Path to the normalization dict json
+            normalization_quantile (float):
+                The quantile to use for normalization of multiplexed data
+            segmentation_naming_convention (Function):
+                Function that takes in the sample name and returns the path to the segmentation
+                .tiff file. Default is None, then it is assumed that the segmentation file is in
+                the sample folder and is named $segmentation_fname.tiff
+            exclude_background_tiles (bool):
+                Whether to exclude the all tiles that only contain background
+            resize (float):
+                The resize factor to use for the images
+            img_suffix (str):
+                The suffix of the image files
+            sample_key (str):
+                The key in the cell table that contains the sample name
+            segment_label_key (str):
+                The key in the cell table that contains the segmentation labels
+            gt_suffix (str):
+                The suffix of the ground truth column in the cell_table
+        """
+        super().__init__()
+        self.selected_markers = selected_markers
+        self.data_dir = data_dir
+        self.normalization_dict_path = normalization_dict_path
+        self.normalization_quantile = normalization_quantile
+        self.segmentation_fname = segmentation_fname
+        self.segment_label_key = segment_label_key
+        self.sample_key = sample_key
+        self.dataset = dataset
+        self.imaging_platform = imaging_platform
+        self.tf_record_path = tf_record_path
+        self.cell_table_path = cell_table_path
+        self.tile_size = tile_size
+        self.stride = stride
+        self.segmentation_naming_convention = segmentation_naming_convention
+        self.exclude_background_tiles = exclude_background_tiles
+        self.resize = resize
+        self.img_suffix = img_suffix
+        self.gt_suffix = gt_suffix
+
+    def get_marker_activity(self, sample_name, marker):
+        """Gets the marker activity for the given labels
+        Args:
+            sample_name (str):
+                The name of the sample
+            conversion_matrix (pd.DataFrame):
+                The conversion matrix to use for the lookup
+            marker (str, list):
+                The markers to get the activity for
+        Returns:
+            np.array:
+                The marker activity for the given labels, 1 if the marker is active, 0
+                otherwise and -1 if the marker is not specific enough to be considered active
+        """
+        cell_types = self.sample_subset[self.cell_type_key].str.lower().values
+
+        df = pd.DataFrame(
+            {
+                "labels": self.sample_subset[self.segment_label_key],
+                "activity": self.sample_subset[self.gt_key],
+                "cell_type": cell_types,
+            }
+        )
+        return df, cell_types
+
+    def check_additional_inputs(self):
+        """Checks additional inputs for correctness"""
+        pass

--- a/cell_classification/simple_data_prep_test.py
+++ b/cell_classification/simple_data_prep_test.py
@@ -4,4 +4,52 @@ import os
 import numpy as np
 import pandas as pd
 from simple_data_prep import SimpleTFRecords
-from segmentation_data_prep_test import prepare_test_data_folders
+from segmentation_data_prep_test import prepare_test_data_folders, prepare_cell_type_table
+import json
+import tempfile
+
+
+def test_get_marker_activity():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        norm_dict = {"CD11c": 1.0, "CD4": 1.0, "CD56": 1.0, "CD57": 1.0}
+        with open(os.path.join(temp_dir, "norm_dict.json"), "w") as f:
+            json.dump(norm_dict, f)
+        data_folders = prepare_test_data_folders(
+            5, temp_dir, list(norm_dict.keys()) + ["XYZ"], random=True,
+            scale=[0.5, 1.0, 1.5, 2.0, 5.0]
+        )
+        cell_table_path = os.path.join(temp_dir, "cell_table.csv")
+        cell_table = pd.DataFrame(
+           {
+                "SampleID": ["fov_0"] * 15 + ["fov_1"] * 15 + ["fov_2"] * 15 + ["fov_3"] * 15 +
+                ["fov_4"] * 15 + ["fov_5"] * 15,
+                "labels": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] * 6,
+                "CD4_gt": [1, 1, 0, 0, 2] * 3 * 3 +
+                [0, 0, 1, 1, 2] * 3 * 3,
+            }
+        )
+
+        cell_table.to_csv(cell_table_path, index=False)
+        data_prep = SimpleTFRecords(
+            data_dir=temp_dir,
+            tf_record_path=temp_dir,
+            cell_table_path=cell_table_path,
+            normalization_dict_path=None,
+            selected_markers=["CD4"],
+            imaging_platform="test",
+            dataset="test",
+            tile_size=[256, 256],
+            stride=[256, 256],
+        )
+        data_prep.load_and_check_input()
+        marker = "CD4"
+        sample_name = "fov_1"
+        fov_1_subset = cell_table[cell_table.SampleID == sample_name]
+        data_prep.sample_subset = fov_1_subset
+        marker_activity, _ = data_prep.get_marker_activity(sample_name, marker)
+
+        # check if the we get marker_acitivity for all labels in the fov_1 subset
+        assert np.array_equal(marker_activity.labels, fov_1_subset.labels)
+
+        # check if the df has the right marker activity values for a given cell
+        assert np.array_equal(marker_activity.activity.values, fov_1_subset.CD4_gt.values)

--- a/cell_classification/simple_data_prep_test.py
+++ b/cell_classification/simple_data_prep_test.py
@@ -1,0 +1,7 @@
+import pytest
+import tempfile
+import os
+import numpy as np
+import pandas as pd
+from simple_data_prep import SimpleTFRecords
+from segmentation_data_prep_test import prepare_test_data_folders


### PR DESCRIPTION
**What is the purpose of this PR?**

This PR closes #41 by adding a subclass `SimpleTFRecords` that inherits from `SegmentationTFRecords`. Instead of requiring a `conversion_matrix`, it requires a cell_table that contains column $marker+`self.gt_suffix` that contains 0s/1s/2s labels for each cell segment. 

**How did you implement your changes**

I subclasses `SegmentationTFRecords`, implemented new functions for `__init__`, `get_image` and `get_inst_binary_masks`. In `SegmentationTFRecords.load_and_check_input` everything that is specific to `conversion_matrix`-based GT-generation is moved to `check_additional_inputs`.

**Remaining issues**

None
