### PR TITLE
Add nuclei, membrane channel and tissue type attribute to tfrecord dataset generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ git:
 language: python
 
 python:
-  - 3.8.0
+  - 3.9.12
 
 install:
   - travis_retry pip install -r requirements.txt

--- a/cell_classification/metrics_test.py
+++ b/cell_classification/metrics_test.py
@@ -1,5 +1,4 @@
-import h5py
-from model_builder_test import prep_object_and_inputs
+from segmentation_data_prep_test import prep_object_and_inputs
 from model_builder import ModelBuilder
 import tempfile
 import toml
@@ -113,4 +112,8 @@ def test_HDF5Generator():
         # check if generator returns the right items
         for sample in generator:
             assert isinstance(sample, dict)
-            assert len(list(sample.keys())) == 11
+            assert set(list(sample.keys())) == set([
+                'binary_mask', 'dataset', 'folder_name', 'imaging_platform', 'instance_mask',
+                'marker', 'marker_activity_mask', 'membrane_img', 'mplex_img', 'nuclei_img',
+                'prediction', 'prediction_mean', 'activity_df'
+            ])

--- a/cell_classification/metrics_test.py
+++ b/cell_classification/metrics_test.py
@@ -115,5 +115,5 @@ def test_HDF5Generator():
             assert set(list(sample.keys())) == set([
                 'binary_mask', 'dataset', 'folder_name', 'imaging_platform', 'instance_mask',
                 'marker', 'marker_activity_mask', 'membrane_img', 'mplex_img', 'nuclei_img',
-                'prediction', 'prediction_mean', 'activity_df'
+                'prediction', 'prediction_mean', 'activity_df', 'tissue_type'
             ])

--- a/cell_classification/model_builder_test.py
+++ b/cell_classification/model_builder_test.py
@@ -66,9 +66,12 @@ def test_prep_data():
         trainer.prep_data()
         val_dset = iter(trainer.validation_dataset)
         val_batch = next(val_dset)
-        assert set(val_batch.keys()) == set([
-                "mplex_img", "binary_mask", "instance_mask", "folder_name", "marker", "dataset",
-                "imaging_platform", "marker_activity_mask", "activity_df"]
+        assert set(val_batch.keys()) == set(
+            [
+                "mplex_img", "binary_mask", "instance_mask", "nuclei_img", "membrane_img",
+                "folder_name", "marker", "dataset", "imaging_platform", "marker_activity_mask",
+                "activity_df"
+            ]
         )
 
 

--- a/cell_classification/model_builder_test.py
+++ b/cell_classification/model_builder_test.py
@@ -70,7 +70,7 @@ def test_prep_data():
             [
                 "mplex_img", "binary_mask", "instance_mask", "nuclei_img", "membrane_img",
                 "folder_name", "marker", "dataset", "imaging_platform", "marker_activity_mask",
-                "activity_df"
+                "activity_df", 'tissue_type'
             ]
         )
 

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -370,7 +370,8 @@ class SegmentationTFRecords:
 
             # check if selected markers are in normalization dict
             verify_in_list(
-                selected_markers=self.selected_markers,
+                selected_markers=self.selected_markers + self.nuclei_channels +
+                self.membrane_channels,
                 normalization_dict_keys=self.normalization_dict.keys(),
             )
         else:

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -352,8 +352,8 @@ class SegmentationTFRecords:
         if not isinstance(self.selected_markers, list):
             self.selected_markers = [self.selected_markers]
 
-        # check if selected markers are in data folders
-        for marker in self.selected_markers:
+        # check if selected markers and nuclei/membrane channels are in data folders
+        for marker in self.selected_markers + self.nuclei_channels + self.membrane_channels:
             exists = False
             for folder in self.data_folders:
                 if os.path.exists(os.path.join(folder, marker + self.img_suffix)):

--- a/cell_classification/segmentation_data_prep.py
+++ b/cell_classification/segmentation_data_prep.py
@@ -17,7 +17,7 @@ class SegmentationTFRecords:
 
     def __init__(
         self, data_dir, cell_table_path, conversion_matrix_path, imaging_platform, dataset,
-        tile_size, stride, tf_record_path, nuclei_channels=[], membrane_channels=[],
+        tissue_type, tile_size, stride, tf_record_path, nuclei_channels=[], membrane_channels=[],
         selected_markers=None, normalization_dict_path=None, normalization_quantile=0.999,
         cell_type_key="cluster_labels", sample_key="SampleID", segment_label_key="labels",
         segmentation_fname="cell_segmentation", segmentation_naming_convention=None,
@@ -36,6 +36,8 @@ class SegmentationTFRecords:
                 The imaging platform used to generate the multiplexed imaging data
             dataset (str):
                 The dataset where the imaging data comes from
+            tissue_type (str):
+                The tissue type of the data
             tile_size list [int,int]:
                 The size of the tiles to use for the segmentation model
             stride list [int,int]:
@@ -81,6 +83,7 @@ class SegmentationTFRecords:
         self.segment_label_key = segment_label_key
         self.sample_key = sample_key
         self.dataset = dataset
+        self.tissue_type = tissue_type
         self.imaging_platform = imaging_platform
         self.tf_record_path = tf_record_path
         self.cell_type_key = cell_type_key
@@ -263,6 +266,7 @@ class SegmentationTFRecords:
             "imaging_platform": self.imaging_platform,
             "marker_activity_mask": marker_activity_mask.astype(np.uint8),
             "dataset": self.dataset,
+            "tissue_type": self.tissue_type,
             "marker": marker,
             "activity_df": marker_activity,
             "folder_name": fov,
@@ -564,6 +568,7 @@ feature_description = {
     "imaging_platform": tf.io.RaggedFeature(tf.int64),
     "marker_activity_mask": tf.io.RaggedFeature(tf.string),
     "dataset": tf.io.RaggedFeature(tf.int64),
+    "tissue_type": tf.io.RaggedFeature(tf.int64),
     "marker": tf.io.RaggedFeature(tf.int64),
     "activity_df": tf.io.RaggedFeature(tf.int64),
     "folder_name": tf.io.RaggedFeature(tf.int64),
@@ -579,7 +584,9 @@ def parse_dict(deserialized_dict):
         a dictionary of tensors and metadata strings
     """
     example = {}
-    for key in ["dataset", "marker", "imaging_platform", "folder_name", "activity_df"]:
+    for key in [
+            "dataset", "tissue_type", "marker", "imaging_platform", "folder_name", "activity_df"
+    ]:
         example[key] = tf.strings.unicode_encode(
             tf.cast(deserialized_dict[key], tf.int32), "UTF-8"
         )

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -142,7 +142,7 @@ def test_calculate_normalization_matrix():
         )
 
         # check if the normalization_dict has the correct values for stochastic images
-        for marker, std in zip(norm_dict.keys(), scale):
+        for marker, std in zip(selected_markers, scale):
             assert np.isclose(norm_dict[marker], std * 0.999, rtol=1e-3)
 
         # check if the normalization_dict is correctly written to the json file
@@ -150,8 +150,7 @@ def test_calculate_normalization_matrix():
         assert norm_dict_loaded == norm_dict
 
         # check if the normalization_dict has the correct keys
-        for marker in selected_markers:
-            assert marker in norm_dict.keys()
+        assert set(selected_markers) == set(norm_dict.keys())
 
 
 def test_load_and_check_input():
@@ -333,6 +332,10 @@ def test_get_inst_binary_masks():
         assert np.array_equal(np.squeeze(loaded_img), instance_mask)
 
 
+def test_get_composite_image():
+    pass
+
+
 def test_get_marker_activity():
 
     data_prep = prep_object()
@@ -412,6 +415,8 @@ def test_tile_example(tile_size):
     example = {
         "mplex_img": np.random.rand(512, 512, 3).astype(np.float32),
         "binary_mask": np.random.randint(0, 2, [512, 512, 1]).astype(np.uint8),
+        "nuclei_img": np.random.rand(512, 512, 1).astype(np.float32),
+        "membrane_img": np.random.rand(512, 512, 1).astype(np.float32),
         "instance_mask": instance_mask,
         "marker_activity_mask": np.random.randint(0, 2, [512, 512, 21]).astype(np.uint8),
         "dataset": "test_dataset",
@@ -477,12 +482,15 @@ def test_prepare_example():
         ]
         data_prep.binary_mask = np.random.randint(0, 2, [256, 256, 1]).astype(np.uint8)
         data_prep.instance_mask = np.zeros([256, 256, 1], dtype=np.uint16)
+        data_prep.nuclei_img = np.zeros([256, 256, 1], dtype=np.uint16)
+        data_prep.membrane_img = np.zeros([256, 256, 1], dtype=np.uint16)
         example = data_prep.prepare_example(data_folders[0], marker="CD4")
         # check keys in example
         assert set(example.keys()) == set(
             [
-                "mplex_img", "binary_mask", "instance_mask", "imaging_platform",
-                "marker_activity_mask", "dataset", "marker", "folder_name", "activity_df",
+                "mplex_img", "binary_mask", "instance_mask", "imaging_platform", "nuclei_img",
+                "membrane_img", "marker_activity_mask", "dataset", "marker", "folder_name",
+                "activity_df",
             ]
         )
 
@@ -503,6 +511,8 @@ def test_serialize_example():
         ]
         data_prep.binary_mask = np.random.randint(0, 2, [256, 256, 1]).astype(np.uint8)
         data_prep.instance_mask = np.zeros([256, 256, 1], dtype=np.uint16)
+        data_prep.nuclei_img = np.zeros([256, 256, 1], dtype=np.uint16)
+        data_prep.membrane_img = np.zeros([256, 256, 1], dtype=np.uint16)
         example = data_prep.prepare_example(os.path.join(temp_dir, "fov_1"), marker="CD4")
         serialized_example = data_prep.serialize_example(copy.deepcopy(example))
         deserialized_dict = tf.io.parse_single_example(serialized_example, feature_description)

--- a/cell_classification/segmentation_data_prep_test.py
+++ b/cell_classification/segmentation_data_prep_test.py
@@ -369,6 +369,13 @@ def test_get_composite_image():
         )[..., np.newaxis]
         assert np.array_equal(membrane_img, membrane_img_loaded)
 
+        # test if the function works for a single channel
+        single_channel_img = data_prep.get_composite_image(data_folders[0], channels=["CD4"])
+        single_channel_img_loaded = imread(os.path.join(data_folders[0], "CD4.tiff"))
+        single_channel_img_loaded /= data_prep.normalization_dict["CD4"]
+        single_channel_img_loaded = single_channel_img_loaded.clip(0, 1)[..., np.newaxis]
+        assert np.array_equal(single_channel_img, single_channel_img_loaded)
+
 
 def test_get_marker_activity():
 

--- a/cell_classification/simple_data_prep.py
+++ b/cell_classification/simple_data_prep.py
@@ -6,10 +6,11 @@ class SimpleTFRecords(SegmentationTFRecords):
     """Prepares the data for the segmentation model"""
     def __init__(
         self, data_dir, cell_table_path, imaging_platform, dataset, tile_size, stride,
-        tf_record_path, selected_markers=None, normalization_dict_path=None,
-        normalization_quantile=0.999, segmentation_naming_convention=None,
-        segmentation_fname="cell_segmentation",  exclude_background_tiles=False, resize=None,
-        img_suffix=".tiff", sample_key="SampleID", segment_label_key="labels", gt_suffix="_gt",
+        tf_record_path, nuclei_channels, membrane_channels, selected_markers=None,
+        normalization_dict_path=None, normalization_quantile=0.999,
+        segmentation_naming_convention=None, segmentation_fname="cell_segmentation",
+        exclude_background_tiles=False, resize=None, img_suffix=".tiff", sample_key="SampleID",
+        segment_label_key="labels", gt_suffix="_gt",
 
     ):
         """Initializes SegmentationTFRecords and loads everything except the images
@@ -56,6 +57,7 @@ class SimpleTFRecords(SegmentationTFRecords):
         super().__init__(
             data_dir=data_dir, cell_table_path=cell_table_path, imaging_platform=imaging_platform,
             dataset=dataset, tile_size=tile_size, stride=stride, tf_record_path=tf_record_path,
+            nuclei_channels=nuclei_channels, membrane_channels=membrane_channels,
             selected_markers=selected_markers, normalization_dict_path=normalization_dict_path,
             normalization_quantile=normalization_quantile, segmentation_fname=segmentation_fname,
             segmentation_naming_convention=segmentation_naming_convention, resize=resize,
@@ -80,6 +82,8 @@ class SimpleTFRecords(SegmentationTFRecords):
         self.resize = resize
         self.img_suffix = img_suffix
         self.gt_suffix = gt_suffix
+        self.nuclei_channels = nuclei_channels
+        self.membrane_channels = membrane_channels
 
     def get_marker_activity(self, sample_name, marker):
         """Gets the marker activity for the given labels

--- a/cell_classification/simple_data_prep.py
+++ b/cell_classification/simple_data_prep.py
@@ -5,7 +5,7 @@ from segmentation_data_prep import SegmentationTFRecords
 class SimpleTFRecords(SegmentationTFRecords):
     """Prepares the data for the segmentation model"""
     def __init__(
-        self, data_dir, cell_table_path, imaging_platform, dataset, tile_size, stride,
+        self, data_dir, cell_table_path, imaging_platform, dataset, tissue_type, tile_size, stride,
         tf_record_path, nuclei_channels, membrane_channels, selected_markers=None,
         normalization_dict_path=None, normalization_quantile=0.999,
         segmentation_naming_convention=None, segmentation_fname="cell_segmentation",
@@ -24,6 +24,8 @@ class SimpleTFRecords(SegmentationTFRecords):
                 The imaging platform used to generate the multiplexed imaging data
             dataset (str):
                 The dataset where the imaging data comes from
+            tissue_type (str):
+                The tissue type of the imaging data
             tile_size list [int,int]:
                 The size of the tiles to use for the segmentation model
             stride list [int,int]:
@@ -62,7 +64,8 @@ class SimpleTFRecords(SegmentationTFRecords):
             normalization_quantile=normalization_quantile, segmentation_fname=segmentation_fname,
             segmentation_naming_convention=segmentation_naming_convention, resize=resize,
             exclude_background_tiles=exclude_background_tiles, img_suffix=img_suffix,
-            sample_key=sample_key, segment_label_key=segment_label_key, conversion_matrix_path=None
+            sample_key=sample_key, segment_label_key=segment_label_key, tissue_type=tissue_type,
+            conversion_matrix_path=None,
         )
         self.selected_markers = selected_markers
         self.data_dir = data_dir
@@ -72,6 +75,7 @@ class SimpleTFRecords(SegmentationTFRecords):
         self.segment_label_key = segment_label_key
         self.sample_key = sample_key
         self.dataset = dataset
+        self.tissue_type = tissue_type
         self.imaging_platform = imaging_platform
         self.tf_record_path = tf_record_path
         self.cell_table_path = cell_table_path

--- a/cell_classification/simple_data_prep_test.py
+++ b/cell_classification/simple_data_prep_test.py
@@ -40,6 +40,8 @@ def test_get_marker_activity():
             dataset="test",
             tile_size=[256, 256],
             stride=[256, 256],
+            nuclei_channels=["CD56"],
+            membrane_channels=["CD57"],
         )
         data_prep.load_and_check_input()
         marker = "CD4"

--- a/cell_classification/simple_data_prep_test.py
+++ b/cell_classification/simple_data_prep_test.py
@@ -38,6 +38,7 @@ def test_get_marker_activity():
             selected_markers=["CD4"],
             imaging_platform="test",
             dataset="test",
+            tissue_type="test",
             tile_size=[256, 256],
             stride=[256, 256],
             nuclei_channels=["CD56"],


### PR DESCRIPTION
**What is the purpose of this PR?**

This PR closes #43. It adds a nuclei and a membrane channel as well as the tissue type to the training examples stored in the tfrecord. Nuclei and membrane channels are calculated as the average of the normalized channels whose names are passed to the init.

**How did you implement your changes**

Class `SegmentationTFRecords` gets three additional inputs: `nuclei_channels`, `membrane_channels` and `tissue_type`. The latter is just directly stored as a string attribute in the tfrecord examples. The former two contain lists of channel names (like `["Ki67", "Dapi"]`) and the channels are loaded with the new class function `SegmentationTFRecords.get_composite_image`. The function loads and normalizes the images and returns the average over the channel dimension.

**Remaining issues**
None