### PR TITLE
Added worst n plots and heatmaps of per cell precision, recall, spec, f1

### DIFF
--- a/cell_classification/evaluation_script.py
+++ b/cell_classification/evaluation_script.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
                 pred, keys=["mplex_img", "marker_activity_mask", "prediction"],
                 save_dir=os.path.join(params["eval_dir"], best_worst + "_predictions"),
                 save_file="worst_{}_{}_{}.png".format(
-                    i, pred["marker"] ,pred["dataset"], pred["folder_name"]
+                    i, pred["marker"], pred["dataset"], pred["folder_name"]
                 )
             )
 

--- a/cell_classification/evaluation_script.py
+++ b/cell_classification/evaluation_script.py
@@ -6,9 +6,7 @@ import pandas as pd
 import numpy as np
 from metrics import load_model_and_val_data, calc_roc, average_roc, calc_metrics
 from plot_utils import plot_average_roc, plot_metrics_against_threshold, subset_plots
-from plot_utils import collapse_activity_dfs, subset_activity_df
-import matplotlib.pyplot as plt
-from metrics import calc_scores
+from plot_utils import heatmap_plot, plot_together
 
 
 if __name__ == "__main__":
@@ -17,51 +15,56 @@ if __name__ == "__main__":
         "--model_path",
         type=str,
         help="Path to model weights",
-        default="C:\\Users\\lorenz\\Desktop\\angelo_lab\\cell_classification\\checkpoints\\" +
-        "ex_2\\ex_2.h5",
+        default=None,
     )
     parser.add_argument(
         "--params_path",
         type=str,
         help="Path to model params",
-        default="C:\\Users\\lorenz\\Desktop\\angelo_lab\\cell_classification\\checkpoints\\"
-        + "ex_2\\params.toml",
+        default="E:\\angelo_lab\\test\\params.toml",
+    )
+    parser.add_argument(
+        "--worst_n",
+        type=int,
+        help="Number of worst predictions to plot",
+        default=20,
     )
     args = parser.parse_args()
     with open(args.params_path, "r") as f:
         params = toml.load(f)
-    params["model_path"] = args.model_path
+    if args.model_path is not None:
+        params["model_path"] = args.model_path
     model, val_dset = load_model_and_val_data(params)
     params["eval_dir"] = os.path.join(*os.path.split(params["model_path"])[:-1], "eval")
     os.makedirs(params["eval_dir"], exist_ok=True)
     pred_list = model.predict_dataset(val_dset, False)
 
-    # pixel level evaluation
-    print("Calculate ROC curve")
-    roc = calc_roc(pred_list)
-    with open(os.path.join(params["eval_dir"], "roc.pkl"), "wb") as f:
-        pickle.dump(roc, f)
-    tprs, mean_tprs, fpr, std, mean_thresh = average_roc(roc)
-    plot_average_roc(mean_tprs, std, save_dir=params["eval_dir"], save_file="avg_roc.png")
-    print("AUC: {}".format(np.mean(roc["auc"])))
-
-    # print("Calculate precision, recall, f1_score and accuracy")
-    # avg_metrics = calc_metrics(pred_list)
-    # pd.DataFrame(avg_metrics).to_csv(
-    #     os.path.join(params["eval_dir"], "pixel_metrics.csv"), index=False
-    # )
-    # plot_metrics_against_threshold(
-    #     avg_metrics,
-    #     metric_keys=["precision", "recall", "f1_score"],
-    #     threshold_key="threshold",
-    #     save_dir=params["eval_dir"],
-    #     save_file="precision_recall_f1.png",
-    # )
+    # prepare cell_table
+    activity_list = []
+    for pred in pred_list:
+        activity_df = pred["activity_df"].copy()
+        for key in ["dataset", "marker", "folder_name"]:
+            activity_df[key] = [pred[key]]*len(activity_df)
+        activity_list.append(activity_df)
+    activity_df = pd.concat(activity_list)
+    activity_df.to_csv(os.path.join(params["eval_dir"], "pred_cell_table.csv"), index=False)
 
     # cell level evaluation
     roc = calc_roc(pred_list, gt_key="activity", pred_key="pred_activity", cell_level=True)
     with open(os.path.join(params["eval_dir"], "roc_cell_lvl.pkl"), "wb") as f:
         pickle.dump(roc, f)
+
+    # find index of n worst predictions and save plots of them
+    worst_idx = np.argsort(roc["auc"])[-args.worst_n:]
+    for i, idx in enumerate(worst_idx):
+        pred = pred_list[idx]
+        plot_together(
+            pred, keys=["mplex_img", "marker_activity_mask", "prediction"],
+            save_dir=os.path.join(params["eval_dir"], "worst_predictions"),
+            save_file="worst_{}_{}_{}.png".format(i, pred["dataset"], pred["folder_name"])
+        )
+
+    pd.DataFrame(roc).auc
     tprs, mean_tprs, fpr, std, mean_thresh = average_roc(roc)
     plot_average_roc(mean_tprs, std, save_dir=params["eval_dir"], save_file="avg_roc_cell_lvl.png")
     print("AUC: {}".format(np.mean(roc["auc"])))
@@ -73,6 +76,7 @@ if __name__ == "__main__":
     pd.DataFrame(avg_metrics).to_csv(
         os.path.join(params["eval_dir"], "cell_metrics.csv"), index=False
     )
+
     plot_metrics_against_threshold(
         avg_metrics,
         metric_keys=["precision", "recall", "f1_score", "specificity"],
@@ -82,10 +86,6 @@ if __name__ == "__main__":
     )
 
     print("Plot activity predictions split by markers and cell types")
-    activity_df = collapse_activity_dfs(pred_list)
-    activity_df.to_csv(
-        os.path.join(params["eval_dir"], "pred_activity_df.csv"), index=False
-    )
     subset_plots(
         activity_df, subset_list=["marker"],
         save_dir=params["eval_dir"],
@@ -93,17 +93,19 @@ if __name__ == "__main__":
         gt_key="activity",
         pred_key="pred_activity",
     )
-    subset_plots(
-        activity_df, subset_list=["cell_type"],
+    if "cell_type" in activity_df.columns:
+        subset_plots(
+            activity_df, subset_list=["cell_type"],
+            save_dir=params["eval_dir"],
+            save_file="split_by_cell_type.png",
+            gt_key="activity",
+            pred_key="pred_activity",
+        )
+    heatmap_plot(
+        activity_df, subset_list=["marker"],
         save_dir=params["eval_dir"],
-        save_file="split_by_cell_type.png",
+        save_file="heatmap_split_by_marker.png",
         gt_key="activity",
         pred_key="pred_activity",
-    )
-    subset_plots(
-        activity_df, subset_list=["cell_type", "marker"],
-        save_dir=params["eval_dir"],
-        save_file="split_by_marker_ct.png",
-        gt_key="activity",
-        pred_key="pred_activity",
+
     )

--- a/cell_classification/plot_utils.py
+++ b/cell_classification/plot_utils.py
@@ -244,7 +244,7 @@ def subset_plots(
         activity_df (pd.DataFrame):
             A dataframe containing the activity of each marker
         subset_list (list):
-            A list of markers you want to plot
+            A list of activity_df colnames that will be used to subset your data
         save_dir (str):
             If specified, a directory where we will save the plot
         save_file (str):
@@ -312,15 +312,16 @@ def subset_plots(
     plt.close()
 
 
-def heatmap_plot(activity_df, subset_list, save_dir=None, save_file=None, dpi=160,
-    gt_key="activity", pred_key="prediction",
+def heatmap_plot(
+    activity_df, subset_list, save_dir=None, save_file=None, dpi=160, gt_key="activity",
+    pred_key="prediction",
 ):
     """Plot the activity of each marker in the subset_list
         Args:
             activity_df (pd.DataFrame):
                 A dataframe containing the activity of each marker
             subset_list (list):
-                A list of markers you want to plot
+                A list of activity_df colnames that will be used to subset your data
             save_dir (str):
                 If specified, a directory where we will save the plot
             save_file (str):
@@ -357,7 +358,7 @@ def heatmap_plot(activity_df, subset_list, save_dir=None, save_file=None, dpi=16
         # save results as csv
         if save_dir:
             os.makedirs(save_dir, exist_ok=True)
-            results.to_csv(os.path.join(save_dir, save_file.split(".")[0]+ "_" + key + ".csv"))
+            results.to_csv(os.path.join(save_dir, save_file.split(".")[0] + "_" + key + ".csv"))
         # plot heatmap
         ax = sns.heatmap(results, annot=True, cbar=False, cmap="viridis", vmin=0, vmax=1)
         ax.set(xlabel="", ylabel="")

--- a/cell_classification/plot_utils_test.py
+++ b/cell_classification/plot_utils_test.py
@@ -3,7 +3,7 @@ from segmentation_data_prep import parse_dict, feature_description
 from segmentation_data_prep_test import prep_object_and_inputs
 import pytest
 import tempfile
-from plot_utils import plot_overlay, plot_together, plot_average_roc, subset_plots
+from plot_utils import plot_overlay, plot_together, plot_average_roc, subset_plots, heatmap_plot
 from plot_utils import plot_metrics_against_threshold, subset_activity_df, collapse_activity_dfs
 from metrics_test import make_pred_list
 from metrics import calc_roc, average_roc, calc_metrics
@@ -45,7 +45,8 @@ def test_plot_together():
         example_encoded = tf.io.parse_single_example(record, feature_description)
         example = parse_dict(example_encoded)
         plot_together(
-            example, save_dir=plot_path, save_file=f"{example['folder_name']}_together.png"
+            example, ["mplex_img", "nuclei_img", "marker_activity_mask"], save_dir=plot_path,
+            save_file=f"{example['folder_name']}_together.png"
         )
 
         # check if plot was saved
@@ -122,3 +123,17 @@ def test_subset_plots():
 
         # check if plots were saved
         assert os.path.exists(os.path.join(plot_path, "split_by_marker.png"))
+
+
+def test_heatmap_plot():
+    pred_list = make_pred_list()
+    activity_df = collapse_activity_dfs(pred_list)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        plot_path = os.path.join(temp_dir, "plots")
+        os.makedirs(plot_path, exist_ok=True)
+        heatmap_plot(
+            activity_df, ["marker"], save_dir=plot_path, save_file="heatmap.png"
+        )
+
+        # check if plot was saved
+        assert os.path.exists(os.path.join(plot_path, "heatmap.png"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ toml
 tables==3.7.0
 packaging==21.3
 h5py==3.7.0
+seaborn==0.12.0


### PR DESCRIPTION
**What is the purpose of this PR?**

This PR closes #45 and adds functionality to automatically generate validation dataset performance metric plots and tables and visualizations of the worst n predictions. In a future PR this will be extended for the case of multiple validation datasets.

**How did you implement your changes**

A heatmap visualization of performance metrics split by marker or cell_type is added as `heatmap_plot` in `plot_utils.py`. Resulting plots look like this
![heatmap_split_by_marker](https://user-images.githubusercontent.com/22618181/214856899-3cd2c9bb-6aad-4ceb-a49e-870341371725.png)

Precision, recall, specificity and f1-scores vs. threshold are plotted together via `plot_metrics_against_threshold` instead of in a facetplot as written in the design doc #45. The resulting plots look like this:
![precision_recall_f1_cell_lvl](https://user-images.githubusercontent.com/22618181/214857529-125e1097-6953-4c42-aa96-eb6489e44c48.png)

I changed some bits in `evaluation_script.py` to plot the worst n predictions and to save the predicted cell_table. Worst n predictions are visualized like this:
![worst_0_MSK_colon_10b0e9ade389_Colon P20 CD3, Foxp1, PDL1, ICOS, CD8, panCK+CK7+CAM5 2__ 52459,17275 _image](https://user-images.githubusercontent.com/22618181/214858045-452753cf-99a4-4b25-971c-b9bdb9c61bc9.png)

**Remaining issues**

1. Is this really what we need for fast evaluation of our experiments or am I missing something?
2. I could've also included the functionality from `evaluation_script.py` as a class function in `ModelBuilder.py`, but I don't see a clear advantage of it yet. Do you have opinions on this?