### PR TITLE
Fixed evaluation_script argparser and model_builder multi-dataset sampling

### DIFF
--- a/cell_classification/evaluation_script.py
+++ b/cell_classification/evaluation_script.py
@@ -65,7 +65,8 @@ if __name__ == "__main__":
             for external_dataset in args.external_datasets
         }
         external_datasets = {
-            key: tf.data.TFRecordDataset(external_datasets[key]) for key in external_datasets.keys()
+            key: tf.data.TFRecordDataset(external_datasets[key])
+            for key in external_datasets.keys()
         }
         external_datasets = {
             name: dataset.map(
@@ -79,11 +80,13 @@ if __name__ == "__main__":
             ) for name, dataset in external_datasets.items()
         }
         external_datasets = {
-            name: dataset.batch(params["batch_size"], drop_remainder=False
-        ) for name, dataset in external_datasets.items()}
+            name: dataset.batch(
+                params["batch_size"], drop_remainder=False
+            ) for name, dataset in external_datasets.items()
+        }
 
         datasets.update(external_datasets)
- 
+
     for name, val_dset in datasets.items():
         params["eval_dir"] = os.path.join(*os.path.split(params["model_path"])[:-1], "eval", name)
         os.makedirs(params["eval_dir"], exist_ok=True)

--- a/cell_classification/evaluation_script.py
+++ b/cell_classification/evaluation_script.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     if hasattr(args, "external_datasets"):
         external_datasets = {
             os.path.split(external_dataset)[-1].split(".")[0]: external_dataset.replace(",", "")
-                for external_dataset in args.external_datasets
+            for external_dataset in args.external_datasets
         }
         external_datasets = {
             name: tf.data.TFRecordDataset(path) for name, path in external_datasets.items()

--- a/cell_classification/evaluation_script.py
+++ b/cell_classification/evaluation_script.py
@@ -1,5 +1,6 @@
 import argparse
 import toml
+import ast
 import os
 import pickle
 import pandas as pd
@@ -45,9 +46,10 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--external_datasets",
-        type=dict,
-        help="Maps dataset name to path to tfrecord",
-        default={},
+        type=str,
+        help="List of paths to tfrecord datasets",
+        nargs='+',
+        default=[],
     )
     args = parser.parse_args()
     with open(args.params_path, "r") as f:
@@ -57,9 +59,13 @@ if __name__ == "__main__":
 
     model = load_model(params)
     datasets = {name: dataset for name, dataset in zip(model.dataset_names, model.test_datasets)}
-    if hasattr(parser, "external_datasets"):
+    if hasattr(args, "external_datasets"):
         external_datasets = {
-            name: tf.data.TFRecordDataset(path) for name, path in args.external_datasets.items()
+            os.path.split(external_dataset)[-1].split(".")[0]: external_dataset.replace(",", "")
+                for external_dataset in args.external_datasets
+        }
+        external_datasets = {
+            name: tf.data.TFRecordDataset(path) for name, path in external_datasets.items()
         }
         external_datasets = {
             name: dataset.map(

--- a/cell_classification/evaluation_script.py
+++ b/cell_classification/evaluation_script.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
             for external_dataset in args.external_datasets
         }
         external_datasets = {
-            name: tf.data.TFRecordDataset(path) for name, path in external_datasets.items()
+            key: tf.data.TFRecordDataset(external_datasets[key]) for key in external_datasets.keys()
         }
         external_datasets = {
             name: dataset.map(
@@ -78,8 +78,12 @@ if __name__ == "__main__":
                 parse_dict, num_parallel_calls=tf.data.AUTOTUNE
             ) for name, dataset in external_datasets.items()
         }
-        datasets.update(external_datasets)
+        external_datasets = {
+            name: dataset.batch(params["batch_size"], drop_remainder=False
+        ) for name, dataset in external_datasets.items()}
 
+        datasets.update(external_datasets)
+ 
     for name, val_dset in datasets.items():
         params["eval_dir"] = os.path.join(*os.path.split(params["model_path"])[:-1], "eval", name)
         os.makedirs(params["eval_dir"], exist_ok=True)

--- a/cell_classification/model_builder.py
+++ b/cell_classification/model_builder.py
@@ -126,7 +126,8 @@ class ModelBuilder:
 
         # merge datasets with tf.data.Dataset.sample_from_datasets
         self.train_dataset = tf.data.Dataset.sample_from_datasets(
-            datasets=self.train_datasets, weights=self.params["dataset_sample_probs"]
+            datasets=self.train_datasets, weights=self.params["dataset_sample_probs"],
+            stop_on_empty_dataset=True
         )
 
         # shuffle, batch and augment the datasets


### PR DESCRIPTION
**What is the purpose of this PR?**

I had to change two small errors that I just realized during model training:
1. We use `tf.data.Dataset.sample_from_datasets(datasets=train_datasets, weights=sample_probs, stop_on_empty_dataset=True)` to sample from the datasets during multi-dataset training. Before we didn't set `stop_on_empty_dataset=True` which resulted in the dataloader to first sample from datasets X, Y, Z according to `sample_probs` until one or more of the datasets ran out of samples, then it continued to draw samples from the remaining datasets until all are empty and the dataloader is restarted. In this PR we set `stop_on_empty_dataset=True` which restarts the dataloader once a dataset is empty.
2. In `evaluation_script.py` we load external datasets for model evaluation. The argparsing functionality I implemented didn't work correctly, resulting in a failure to load these external datasets. This is now fixed.

**How did you implement your changes**

Changed only 2-3 lines of code..

**Remaining issues**

None
