### PR TITLE
Added dataset and marker filtering

### DIFF
--- a/tests/model_builder_test.py
+++ b/tests/model_builder_test.py
@@ -522,3 +522,25 @@ def test_fov_filter(config_params):
             for example in dataset_filtered:
                 fov_list.append(example["folder_name"].numpy().decode())
             assert set(fov) == set(fov_list)
+
+
+def dset_marker_filter(config_params):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        data_prep, _, _, _ = prep_object_and_inputs(tmp_dir)
+        data_prep.tf_record_path = tmp_dir
+        data_prep.make_tf_record()
+        tf_record_path = os.path.join(data_prep.tf_record_path, data_prep.dataset + ".tfrecord")
+        config_params["record_path"] = [tf_record_path]
+        config_params["path"] = tmp_dir
+        config_params["experiment"] = "test"
+        config_params["dataset_names"] = ["test1"]
+        config_params["num_steps"] = 5
+        config_params["batch_size"] = 1
+        config_params["exclude_dset_marker_dict"] = {"test1": ["CD4"]}
+        trainer = ModelBuilder(config_params)
+        dataset = tf.data.TFRecordDataset(tf_record_path)
+        dataset = dataset.map(lambda x: tf.io.parse_single_example(x, feature_description))
+        dataset = dataset.map(parse_dict)
+        dataset_filtered = trainer.dset_marker_filter(dataset)
+        for example in dataset_filtered:
+            assert example["marker"].numpy().decode() != "CD4"


### PR DESCRIPTION
**What is the purpose of this PR?**

We found that some channels (Ki67, IDO1, PDL1) in the decidua dataset had erroneous labels in the silver standard datasets. To exclude these markers from training I added a filtering functionality, that filters samples with this dataset and marker combination from the training data.

**How did you implement your changes**

Included a filtering class function in the `ModelBuilder` class.

**Remaining issues**
None