### PR TITLE
Changed unet final layer activation and name

### DIFF
--- a/src/cell_classification/unet.py
+++ b/src/cell_classification/unet.py
@@ -294,8 +294,7 @@ def build_model(nx: Optional[int] = None,
                       padding="valid",
                       data_format=data_format)(x)
 
-    x = layers.Activation(activation)(x)
-    outputs = layers.Activation("softmax", name="outputs")(x)
+    outputs = layers.Activation("sigmoid", name="semantic_head")(x)
     model = Model(inputs, outputs, name="unet")
 
     return model

--- a/tests/unet_test.py
+++ b/tests/unet_test.py
@@ -138,7 +138,7 @@ class TestUnetModel:
 
         input_shape = model.get_layer("inputs").output.shape
         assert tuple(input_shape) == (None, nx, ny, channels)
-        output_shape = model.get_layer("outputs").output.shape
+        output_shape = model.get_layer("semantic_head").output.shape
         assert tuple(output_shape) == (None, nx, ny, num_classes)
 
         # valid padding
@@ -158,7 +158,7 @@ class TestUnetModel:
 
         input_shape = model.get_layer("inputs").output.shape
         assert tuple(input_shape) == (None, nx, ny, channels)
-        output_shape = model.get_layer("outputs").output.shape
+        output_shape = model.get_layer("semantic_head").output.shape
         assert tuple(output_shape) == (None, 388, 388, num_classes)
 
         filters_per_layer = [filters_root, 128, 256, 512, 1024, 512, 256, 128, filters_root]


### PR DESCRIPTION
**What is the purpose of this PR?**

Fixed a problem with tensorflow static graph mode. The loss node is connected to a layer whose name starts with "semantic_" as this name indicated the last layer of the deepcell models. I renamed the last layer of the unet "semantic_head" instead of "outputs". In addition I change the last layer activation from softmax to sigmoid, since we do binary classification.

**How did you implement your changes**

Changed two lines of code.

**Remaining issues**
None